### PR TITLE
[#30] ServiceWorker caching

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -18,6 +18,11 @@
         "react-dom": "^19.2.4",
         "react-router": "^7.14.1",
         "vite-plugin-pwa": "^1.2.0",
+        "workbox-cacheable-response": "^7.4.0",
+        "workbox-expiration": "^7.4.0",
+        "workbox-precaching": "^7.4.0",
+        "workbox-routing": "^7.4.0",
+        "workbox-strategies": "^7.4.0",
         "workbox-window": "^7.4.0"
       },
       "devDependencies": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -21,6 +21,11 @@
     "react-dom": "^19.2.4",
     "react-router": "^7.14.1",
     "vite-plugin-pwa": "^1.2.0",
+    "workbox-cacheable-response": "^7.4.0",
+    "workbox-expiration": "^7.4.0",
+    "workbox-precaching": "^7.4.0",
+    "workbox-routing": "^7.4.0",
+    "workbox-strategies": "^7.4.0",
     "workbox-window": "^7.4.0"
   },
   "devDependencies": {

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -11,7 +11,7 @@ export const App = () => {
   return (
     <Layout>
       {error && <div className={styles.errorBanner}>{error}</div>}
-      {storage.persisted === false && (
+      {storage.persisted === false && !navigator.onLine && (
         <div className={styles.warningBanner}>
           Offline storage may be limited. Reports queued offline could be lost
           if storage is full.

--- a/frontend/src/sw.ts
+++ b/frontend/src/sw.ts
@@ -1,0 +1,142 @@
+/// <reference lib="webworker" />
+import { precacheAndRoute } from "workbox-precaching";
+import { registerRoute } from "workbox-routing";
+import { CacheFirst, NetworkFirst } from "workbox-strategies";
+import { ExpirationPlugin } from "workbox-expiration";
+import { CacheableResponsePlugin } from "workbox-cacheable-response";
+
+declare let self: ServiceWorkerGlobalScope;
+
+// Precache app shell (manifest injected by VitePWA)
+precacheAndRoute(self.__WB_MANIFEST);
+
+// OSM raster tiles — CacheFirst
+registerRoute(
+  ({ url }) => url.hostname === "tile.openstreetmap.org",
+  new CacheFirst({
+    cacheName: "osm-tiles-cache",
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 60 * 60 * 24 * 30,
+        maxEntries: 2000,
+      }),
+    ],
+  }),
+);
+
+// UNDP design system assets
+registerRoute(
+  ({ url }) =>
+    url.hostname === "cdn.jsdelivr.net" && url.pathname.includes("@undp/"),
+  new CacheFirst({
+    cacheName: "undp-assets-cache",
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 60 * 60 * 24 * 90,
+        maxEntries: 100,
+      }),
+    ],
+  }),
+);
+
+// PMTiles range requests — custom handler
+// Cache API rejects 206 responses, so we wrap them as 200 before caching
+// Cache key includes the Range header to store each partial response separately
+const PMTILES_CACHE = "pmtiles-cache";
+
+registerRoute(
+  ({ url }) => url.hostname === "data.source.coop",
+  async ({ request }) => {
+    const range = request.headers.get("Range") || "";
+    const cacheKey = new Request(`${request.url}?_r=${encodeURIComponent(range)}`, {
+      method: "GET",
+    });
+
+    const cache = await caches.open(PMTILES_CACHE);
+    const cached = await cache.match(cacheKey);
+    if (cached) {
+      // Reconstruct the original 206 response from our cached 200
+      const body = await cached.arrayBuffer();
+      return new Response(body, {
+        status: 206,
+        statusText: "Partial Content",
+        headers: {
+          "Content-Type": cached.headers.get("Content-Type") || "application/octet-stream",
+          "Content-Length": String(body.byteLength),
+          "Content-Range": cached.headers.get("X-Original-Content-Range") || "",
+        },
+      });
+    }
+
+    try {
+      const response = await fetch(request);
+
+      if (response.ok || response.status === 206) {
+        const body = await response.arrayBuffer();
+
+        // Store as 200 so Cache API accepts it, preserve original headers
+        const headers = new Headers({
+          "Content-Type": response.headers.get("Content-Type") || "application/octet-stream",
+          "Content-Length": String(body.byteLength),
+          "X-Original-Content-Range": response.headers.get("Content-Range") || "",
+          "X-Cached-At": new Date().toISOString(),
+        });
+
+        const cacheResponse = new Response(body, {
+          status: 200,
+          statusText: "OK",
+          headers,
+        });
+
+        await cache.put(cacheKey, cacheResponse);
+
+        // Return original 206 to the caller
+        return new Response(body, {
+          status: response.status,
+          statusText: response.statusText,
+          headers: response.headers,
+        });
+      }
+
+      return response;
+    } catch {
+      return new Response("Offline — tile not cached", { status: 503 });
+    }
+  },
+);
+
+// API GET /reports — NetworkFirst with timeout
+registerRoute(
+  ({ url, request }) =>
+    url.pathname.includes("/reports") && request.method === "GET",
+  new NetworkFirst({
+    cacheName: "api-reports-cache",
+    networkTimeoutSeconds: 10,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 60 * 5,
+        maxEntries: 50,
+      }),
+    ],
+  }),
+);
+
+// API GET /health — NetworkFirst
+registerRoute(
+  ({ url, request }) =>
+    url.pathname.endsWith("/health") && request.method === "GET",
+  new NetworkFirst({
+    cacheName: "api-health-cache",
+    networkTimeoutSeconds: 5,
+    plugins: [
+      new CacheableResponsePlugin({ statuses: [0, 200] }),
+      new ExpirationPlugin({
+        maxAgeSeconds: 60,
+        maxEntries: 1,
+      }),
+    ],
+  }),
+);

--- a/frontend/src/utils/api.ts
+++ b/frontend/src/utils/api.ts
@@ -1,17 +1,32 @@
 const API_BASE = (import.meta.env.VITE_API_URL ?? "").replace(/\/+$/, "");
 
-export const api = async (path: string, options?: RequestInit) => {
+const DEFAULT_TIMEOUT = 10000;
+
+export const api = async (
+  path: string,
+  options?: RequestInit & { timeout?: number },
+) => {
+  const { timeout = DEFAULT_TIMEOUT, ...fetchOptions } = options ?? {};
   const url = `${API_BASE}${path}`;
-  const res = await fetch(url, {
-    ...options,
-    headers: {
-      "Content-Type": "application/json",
-      ...options?.headers,
-    },
-  });
-  if (!res.ok) {
-    const body = await res.text();
-    throw new Error(`API error ${res.status}: ${body}`);
+
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), timeout);
+
+  try {
+    const res = await fetch(url, {
+      ...fetchOptions,
+      signal: controller.signal,
+      headers: {
+        "Content-Type": "application/json",
+        ...fetchOptions.headers,
+      },
+    });
+    if (!res.ok) {
+      const body = await res.text();
+      throw new Error(`API error ${res.status}: ${body}`);
+    }
+    return res.json();
+  } finally {
+    clearTimeout(timeoutId);
   }
-  return res.json();
 };

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -7,6 +7,9 @@ export default defineConfig({
     react(),
     VitePWA({
       registerType: "autoUpdate",
+      strategies: "injectManifest",
+      srcDir: "src",
+      filename: "sw.ts",
       includeAssets: ["favicon.svg"],
       manifest: {
         name: "TERRA",
@@ -31,20 +34,8 @@ export default defineConfig({
           },
         ],
       },
-      workbox: {
+      injectManifest: {
         globPatterns: ["**/*.{js,css,html,svg,png,woff2}"],
-        runtimeCaching: [
-          {
-            urlPattern: /^https:\/\/.*\.pmtiles/,
-            handler: "CacheFirst",
-            options: {
-              cacheName: "pmtiles-cache",
-              rangeRequests: true,
-              cacheableResponse: { statuses: [0, 200, 206] },
-              expiration: { maxAgeSeconds: 60 * 60 * 24 * 30 },
-            },
-          },
-        ],
       },
     }),
   ],


### PR DESCRIPTION
closes #30

 - add service worker strategy
 - switch to injectManifest to handle custom 206 handling for pmtile partials
 - have persistent storage banner only appear if both false and offline
