### PR TITLE
[#114] Background sync engine

### DIFF
--- a/backend/src/handlers/api.py
+++ b/backend/src/handlers/api.py
@@ -21,7 +21,8 @@ def health():
 @app.post("/photos/upload")
 @tracer.capture_method
 def post_photo_upload():
-    return get_upload_url()
+    body = app.current_event.json_body if app.current_event.body else None
+    return get_upload_url(body)
 
 
 @app.get("/reports")

--- a/backend/src/handlers/photos.py
+++ b/backend/src/handlers/photos.py
@@ -7,15 +7,28 @@ from aws_lambda_powertools import Logger
 logger = Logger()
 s3 = boto3.client("s3")
 
-def get_upload_url() -> dict:
+ALLOWED_TYPES = {
+    "image/jpeg": ".jpg",
+    "image/png": ".png",
+    "image/webp": ".webp",
+}
+
+
+def get_upload_url(body: dict | None = None) -> dict:
     bucket = os.environ.get("PHOTOS_BUCKET", "")
-    photo_key = f"uploads/{uuid.uuid4()}.jpg"
+    content_type = (body or {}).get("content_type", "image/jpeg")
+
+    if content_type not in ALLOWED_TYPES:
+        content_type = "image/jpeg"
+
+    ext = ALLOWED_TYPES[content_type]
+    photo_key = f"uploads/{uuid.uuid4()}{ext}"
     presigned_url = s3.generate_presigned_url(
         "put_object",
         Params={
             "Bucket": bucket,
             "Key": photo_key,
-            "ContentType": "image/jpeg",
+            "ContentType": content_type,
         },
         ExpiresIn=900,
     )

--- a/backend/tests/test_photos.py
+++ b/backend/tests/test_photos.py
@@ -42,3 +42,30 @@ class TestGetUploadUrl:
         result2 = get_upload_url()
 
         assert result1["photo_key"] != result2["photo_key"]
+
+    @patch("src.handlers.photos.s3")
+    @patch.dict(os.environ, {"PHOTOS_BUCKET": "test-bucket"})
+    def test_png_content_type(self, mock_s3):
+        mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+        result = get_upload_url({"content_type": "image/png"})
+
+        assert result["photo_key"].endswith(".png")
+        mock_s3.generate_presigned_url.assert_called_once_with(
+            "put_object",
+            Params={
+                "Bucket": "test-bucket",
+                "Key": result["photo_key"],
+                "ContentType": "image/png",
+            },
+            ExpiresIn=900,
+        )
+
+    @patch("src.handlers.photos.s3")
+    @patch.dict(os.environ, {"PHOTOS_BUCKET": "test-bucket"})
+    def test_invalid_content_type_defaults_to_jpeg(self, mock_s3):
+        mock_s3.generate_presigned_url.return_value = "https://s3.example.com/presigned"
+
+        result = get_upload_url({"content_type": "application/pdf"})
+
+        assert result["photo_key"].endswith(".jpg")

--- a/docs/offline-connectivity-scenarios.md
+++ b/docs/offline-connectivity-scenarios.md
@@ -270,7 +270,8 @@ erDiagram
     PENDING_REPORTS {
         string id PK "offline_queue_id"
         string status "pending | syncing | synced | failed"
-        blob photo "compressed JPEG blob"
+        arraybuffer photo "compressed image as ArrayBuffer (not Blob — Firefox IDB blob handles invalidate)"
+        string photo_content_type "image/jpeg, image/png, etc."
         string photo_key "S3 key (set after upload)"
         float latitude
         float longitude

--- a/frontend/src/app.module.css
+++ b/frontend/src/app.module.css
@@ -11,3 +11,10 @@
   color: var(--undpds-color-black);
   font-size: 0.8125rem;
 }
+
+.syncBanner {
+  padding: 8px 16px;
+  background: var(--undpds-color-blue-200);
+  color: var(--undpds-color-black);
+  font-size: 0.8125rem;
+}

--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -4,26 +4,40 @@ import { useGeolocation } from "./hooks/use-geolocation";
 import { useConnectivity } from "./hooks/use-connectivity";
 import { usePersistentStorage } from "./hooks/use-persistent-storage";
 import { usePrefetchTiles } from "./hooks/use-prefetch-tiles";
+import { useSync } from "./hooks/use-sync";
 import styles from "./app.module.css";
 
 export const App = () => {
   const { latitude, longitude, accuracy, error } = useGeolocation();
-  const connectivity = useConnectivity();
+  const { isOnline, isVerified, onReconnect } = useConnectivity();
   const storage = usePersistentStorage();
+  const { counts } = useSync({ isOnline, isVerified }, onReconnect);
   usePrefetchTiles(latitude, longitude);
+
+  const pendingCount = counts.pending + counts.syncing;
 
   return (
     <Layout>
       {error && <div className={styles.errorBanner}>{error}</div>}
-      {!connectivity.isOnline && (
+      {!isOnline && (
         <div className={styles.warningBanner}>
           You are offline. Reports will be queued and synced when connectivity returns.
         </div>
       )}
-      {storage.persisted === false && !connectivity.isOnline && (
+      {storage.persisted === false && !isOnline && (
         <div className={styles.warningBanner}>
           Offline storage may be limited. Reports queued offline could be lost
           if storage is full.
+        </div>
+      )}
+      {pendingCount > 0 && isOnline && (
+        <div className={styles.syncBanner}>
+          Syncing {pendingCount} report{pendingCount !== 1 ? "s" : ""}...
+        </div>
+      )}
+      {counts.failed > 0 && (
+        <div className={styles.errorBanner}>
+          {counts.failed} report{counts.failed !== 1 ? "s" : ""} failed to sync.
         </div>
       )}
       <ReportFlow

--- a/frontend/src/components/photo-capture.tsx
+++ b/frontend/src/components/photo-capture.tsx
@@ -44,8 +44,10 @@ export const PhotoCapture = ({ onPhotoUploaded }: PhotoCaptureProps) => {
         try {
           setState("uploading");
           setProgress(0);
+          const contentType = compressed.type || "image/jpeg";
           const { photo_key, upload_url } = await api("/photos/upload", {
             method: "POST",
+            body: JSON.stringify({ content_type: contentType }),
           });
 
           await uploadWithProgress(upload_url, compressed, (pct) => {
@@ -172,7 +174,7 @@ const uploadWithProgress = (
   return new Promise((resolve, reject) => {
     const xhr = new XMLHttpRequest();
     xhr.open("PUT", url);
-    xhr.setRequestHeader("Content-Type", "image/jpeg");
+    xhr.setRequestHeader("Content-Type", file.type || "image/jpeg");
 
     xhr.upload.addEventListener("progress", (e) => {
       if (e.lengthComputable) {

--- a/frontend/src/components/report-flow.tsx
+++ b/frontend/src/components/report-flow.tsx
@@ -58,7 +58,8 @@ export const ReportFlow = ({
       // Queue to IndexedDB — background sync handles the actual upload
       await reportQueue.add({
         id: crypto.randomUUID(),
-        photo: photo?.blob ?? null,
+        photo: photo?.blob ? await photo.blob.arrayBuffer() : null,
+        photoContentType: photo?.blob?.type ?? null,
         photoKey: photo?.photoKey ?? null,
         latitude,
         longitude,

--- a/frontend/src/hooks/use-sync.ts
+++ b/frontend/src/hooks/use-sync.ts
@@ -1,0 +1,53 @@
+import { useState, useEffect, useCallback } from "react";
+import { syncEngine } from "../utils/sync-engine";
+import type { ConnectivityState } from "./use-connectivity";
+
+export interface QueueCounts {
+  pending: number;
+  syncing: number;
+  synced: number;
+  failed: number;
+}
+
+const EMPTY_COUNTS: QueueCounts = { pending: 0, syncing: 0, synced: 0, failed: 0 };
+
+export const useSync = (
+  connectivity: ConnectivityState,
+  onReconnect: (cb: () => void) => () => void,
+) => {
+  const [counts, setCounts] = useState<QueueCounts>(EMPTY_COUNTS);
+
+  // Listen for queue status changes
+  useEffect(() => {
+    return syncEngine.onStatusChange(setCounts);
+  }, []);
+
+  // Process queue on reconnect
+  useEffect(() => {
+    return onReconnect(() => {
+      syncEngine.processQueue();
+    });
+  }, [onReconnect]);
+
+  // Process queue when connectivity is verified
+  useEffect(() => {
+    if (connectivity.isVerified) {
+      syncEngine.processQueue();
+    }
+  }, [connectivity.isVerified]);
+
+  // Periodic poll every 30s while online
+  useEffect(() => {
+    if (!connectivity.isOnline) return;
+    const interval = setInterval(() => {
+      syncEngine.processQueue();
+    }, 30000);
+    return () => clearInterval(interval);
+  }, [connectivity.isOnline]);
+
+  const manualSync = useCallback(() => {
+    syncEngine.processQueue();
+  }, []);
+
+  return { counts, manualSync };
+};

--- a/frontend/src/utils/report-queue.ts
+++ b/frontend/src/utils/report-queue.ts
@@ -7,7 +7,8 @@ export type ReportStatus = "pending" | "syncing" | "synced" | "failed";
 export interface QueuedReport {
   id: string; // offline_queue_id
   status: ReportStatus;
-  photo: Blob | null;
+  photo: ArrayBuffer | null;
+  photoContentType: string | null;
   photoKey: string | null; // set after photo upload succeeds
   latitude: number;
   longitude: number;

--- a/frontend/src/utils/sync-engine.ts
+++ b/frontend/src/utils/sync-engine.ts
@@ -1,0 +1,148 @@
+import { reportQueue } from "./report-queue";
+import type { QueuedReport } from "./report-queue";
+import { api } from "./api";
+
+const MAX_RETRIES = 10;
+const BASE_BACKOFF_MS = 2000;
+
+type SyncListener = (counts: { pending: number; syncing: number; synced: number; failed: number }) => void;
+
+let running = false;
+let listeners: SyncListener[] = [];
+
+const notifyListeners = async () => {
+  const counts = await reportQueue.getCounts();
+  for (const listener of listeners) {
+    listener(counts);
+  }
+};
+
+export const syncEngine = {
+  onStatusChange(listener: SyncListener) {
+    listeners.push(listener);
+    return () => {
+      listeners = listeners.filter((l) => l !== listener);
+    };
+  },
+
+  async processQueue() {
+    if (running) return;
+    if (!navigator.onLine) return;
+
+    running = true;
+
+    try {
+      const pending = await reportQueue.getByStatus("pending");
+      const failed = await reportQueue.getByStatus("failed");
+      const retryable = failed.filter((r) => r.retryCount < MAX_RETRIES);
+      const toProcess = [...pending, ...retryable];
+
+      for (const report of toProcess) {
+        if (!navigator.onLine) break;
+        await syncEngine.syncReport(report);
+        await notifyListeners();
+      }
+    } finally {
+      running = false;
+      await notifyListeners();
+
+      // Re-check for pending reports (failures with backoff get set back to pending)
+      if (navigator.onLine) {
+        const remaining = await reportQueue.getByStatus("pending");
+        if (remaining.length > 0) {
+          syncEngine.processQueue();
+        }
+      }
+    }
+  },
+
+  async syncReport(report: QueuedReport) {
+    await reportQueue.updateStatus(report.id, "syncing", {
+      lastAttempt: new Date().toISOString(),
+    });
+    await notifyListeners();
+
+    try {
+      let photoKey = report.photoKey;
+      if (report.photo && !photoKey) {
+        const contentType = report.photoContentType || "image/jpeg";
+        const blob = new Blob([report.photo], { type: contentType });
+        photoKey = await uploadPhoto(blob, contentType);
+        await reportQueue.updateStatus(report.id, "syncing", { photoKey });
+      }
+
+      const result = await api("/reports", {
+        method: "POST",
+        body: JSON.stringify({
+          latitude: report.latitude,
+          longitude: report.longitude,
+          s2_id: report.s2Id,
+          location_description: report.locationDescription,
+          damage_level: report.damageLevel,
+          photo_key: photoKey,
+          infrastructure_type: report.surveyData.infrastructureType,
+          infrastructure_type_other: report.surveyData.infrastructureTypeOther || null,
+          infrastructure_name: report.surveyData.infrastructureName || null,
+          crisis_nature: report.surveyData.crisisNature,
+          debris_present: report.surveyData.debrisPresent,
+          electricity_status: report.surveyData.electricityStatus || null,
+          health_status: report.surveyData.healthStatus || null,
+          pressing_needs: report.surveyData.pressingNeeds,
+          pressing_needs_other: report.surveyData.pressingNeedsOther || null,
+          offline_queue_id: report.id,
+        }),
+      });
+
+      if (result.status === "created" || result.status === "duplicate") {
+        await reportQueue.updateStatus(report.id, "synced", {
+          syncedAt: new Date().toISOString(),
+        });
+      }
+    } catch (err) {
+      const message = err instanceof Error ? err.message : "Unknown error";
+      const is4xx = message.includes("API error 4");
+
+      if (is4xx) {
+        await reportQueue.updateStatus(report.id, "failed", {
+          error: message,
+          retryCount: MAX_RETRIES,
+        });
+      } else {
+        const retryCount = report.retryCount + 1;
+        if (retryCount >= MAX_RETRIES) {
+          await reportQueue.updateStatus(report.id, "failed", {
+            error: `Max retries exceeded: ${message}`,
+            retryCount,
+          });
+        } else {
+          await reportQueue.updateStatus(report.id, "pending", {
+            error: message,
+            retryCount,
+          });
+          const backoff = Math.min(BASE_BACKOFF_MS * Math.pow(2, retryCount - 1), 60000);
+          await new Promise((r) => setTimeout(r, backoff));
+        }
+      }
+      await notifyListeners();
+    }
+  },
+};
+
+async function uploadPhoto(blob: Blob, contentType: string): Promise<string> {
+  const { photo_key, upload_url } = await api("/photos/upload", {
+    method: "POST",
+    body: JSON.stringify({ content_type: contentType }),
+  });
+
+  const response = await fetch(upload_url, {
+    method: "PUT",
+    body: blob,
+    headers: { "Content-Type": contentType },
+  });
+
+  if (!response.ok) {
+    throw new Error(`Photo upload failed: ${response.status}`);
+  }
+
+  return photo_key;
+}


### PR DESCRIPTION
closes #114

 - add background sync engine for processing pending reports when back online
 - offline queue id for idempotency
 - retrigger on fail
 - periodic sync while online
 - update docs
