### PR TITLE
[#54] Simple duplicate & reassessment detection

### DIFF
--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -74,7 +74,7 @@ class ReportsQueryParams(BaseModel):
     offset: int = Field(0, ge=0)
 
 
-def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> dict:
+def _check_for_duplicates(conn, submission: ReportSubmission) -> dict:
     """
     Check for duplicate or reassessment reports.
 

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -173,7 +173,7 @@ def create_report(body: dict) -> dict:
 
     # Check for duplicates/reassessments
     conn = get_connection()
-    duplicate_check = _check_for_duplicates(conn, submission, h3_r12)
+    duplicate_check = _check_for_duplicates(conn, submission)
 
     # Insert report
     report_id = str(uuid.uuid4())

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -110,20 +110,21 @@ def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> di
 
         # Check 2: Same location + recent (within 2 minutes, 15m radius)
         # This catches accidental double-submits
+        # Cast to geography so ST_DWithin uses meters, not degrees.
         time_threshold = datetime.now(timezone.utc) - timedelta(seconds=DUPLICATE_TIME_WINDOW_SECONDS)
         cur.execute(
-            f"""
+            """
             SELECT id FROM reports
             WHERE ST_DWithin(
-                location,
-                ST_SetSRID(ST_MakePoint(%s, %s), 4326),
-                {DUPLICATE_DISTANCE_METERS}
+                location::geography,
+                ST_SetSRID(ST_MakePoint(%s, %s), 4326)::geography,
+                %s
             )
             AND submitted_at > %s
             ORDER BY submitted_at DESC
             LIMIT 1
             """,
-            (submission.longitude, submission.latitude, time_threshold),
+            (submission.longitude, submission.latitude, DUPLICATE_DISTANCE_METERS, time_threshold),
         )
         result = cur.fetchone()
         if result:

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -353,7 +353,7 @@ def query_reports(params: dict) -> dict:
                 "is_latest": row[18],
                 "submitted_at": row[19].isoformat() if row[19] else None,
                 "duplicate_status": row[20],
-                "related_report_id": row[21],
+                "related_report_id": str(row[21]) if row[21] else None,
                 "version_count": row[22],
             },
         })

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime
+from datetime import datetime, timedelta
 
 import boto3
 import h3
@@ -13,6 +13,10 @@ logger = Logger()
 s3 = boto3.client("s3")
 
 PHOTO_URL_EXPIRY_SECONDS = 3600
+
+# Duplicate detection thresholds
+DUPLICATE_TIME_WINDOW_SECONDS = 120  # 2 minutes
+DUPLICATE_DISTANCE_METERS = 15  # 15m radius
 
 
 def _presigned(uri: str | None) -> str | None:
@@ -70,6 +74,67 @@ class ReportsQueryParams(BaseModel):
     offset: int = Field(0, ge=0)
 
 
+def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> dict:
+    """
+    Check for duplicate or reassessment reports.
+    
+    Returns dict with keys:
+    - duplicate_status: None | 'possible_duplicate' | 'reassessment'
+    - related_report_id: UUID of related report (if any)
+    
+    Logic:
+    1. If same building_id → reassessment (intentional re-assessment)
+    2. Else if same location + recent → possible_duplicate (accidental double-submit)
+    3. Else → no flag
+    
+    Note: reassessment takes precedence over duplicate (building_id is explicit intent).
+    """
+    with conn.cursor() as cur:
+        # Check 1: Same building → reassessment
+        if submission.building_id:
+            cur.execute(
+                """
+                SELECT id FROM reports
+                WHERE building_id = %s
+                ORDER BY submitted_at DESC
+                LIMIT 1
+                """,
+                (submission.building_id,),
+            )
+            result = cur.fetchone()
+            if result:
+                return {
+                    "duplicate_status": "reassessment",
+                    "related_report_id": str(result[0]),
+                }
+        
+        # Check 2: Same location + recent (within 2 minutes, 15m radius)
+        # This catches accidental double-submits
+        time_threshold = datetime.now(datetime.timezone.utc) - timedelta(seconds=DUPLICATE_TIME_WINDOW_SECONDS)
+        cur.execute(
+            f"""
+            SELECT id FROM reports
+            WHERE ST_DWithin(
+                location,
+                ST_SetSRID(ST_MakePoint(%s, %s), 4326),
+                {DUPLICATE_DISTANCE_METERS}
+            )
+            AND submitted_at > %s
+            ORDER BY submitted_at DESC
+            LIMIT 1
+            """,
+            (submission.longitude, submission.latitude, time_threshold),
+        )
+        result = cur.fetchone()
+        if result:
+            return {
+                "duplicate_status": "possible_duplicate",
+                "related_report_id": str(result[0]),
+            }
+    
+    return {"duplicate_status": None, "related_report_id": None}
+
+
 def create_report(body: dict) -> dict:
     submission = ReportSubmission(**body)
 
@@ -105,9 +170,12 @@ def create_report(body: dict) -> dict:
         stem = submission.photo_key[len("uploads/"):].rsplit(".", 1)[0]
         thumbnail_url = f"s3://{photos_bucket}/thumbnails/{stem}.jpg"
 
+    # Check for duplicates/reassessments
+    conn = get_connection()
+    duplicate_check = _check_for_duplicates(conn, submission, h3_r12)
+
     # Insert report
     report_id = str(uuid.uuid4())
-    conn = get_connection()
     with conn.cursor() as cur:
         cur.execute(
             """
@@ -117,10 +185,10 @@ def create_report(body: dict) -> dict:
                 photo_url, thumbnail_url, infrastructure_type, infrastructure_description,
                 crisis_nature, debris_present, electricity_status,
                 health_status, pressing_needs, version_chain_id,
-                device_id, offline_queue_id
+                device_id, offline_queue_id, duplicate_status, related_report_id
             ) VALUES (
                 %s, ST_SetSRID(ST_MakePoint(%s, %s), 4326), %s, %s, %s,
-                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
+                %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s, %s
             )
             """,
             (
@@ -146,6 +214,8 @@ def create_report(body: dict) -> dict:
                 str(version_chain_id),
                 submission.device_id,
                 submission.offline_queue_id,
+                duplicate_check["duplicate_status"],
+                duplicate_check["related_report_id"],
             ),
         )
 
@@ -163,6 +233,8 @@ def create_report(body: dict) -> dict:
         "status": "created",
         "area_report_count": area_count,
         "version_chain_id": str(version_chain_id),
+        "duplicate_status": duplicate_check["duplicate_status"],
+        "related_report_id": duplicate_check["related_report_id"],
     }
 
 
@@ -234,6 +306,7 @@ def query_reports(params: dict) -> dict:
                 crisis_nature, debris_present, electricity_status,
                 health_status, pressing_needs, version_chain_id,
                 is_latest, submitted_at,
+                duplicate_status, related_report_id,
                 (SELECT COUNT(*) FROM reports r2
                  WHERE r2.version_chain_id = reports.version_chain_id) as version_count
             FROM reports
@@ -278,7 +351,9 @@ def query_reports(params: dict) -> dict:
                 "version_chain_id": str(row[17]),
                 "is_latest": row[18],
                 "submitted_at": row[19].isoformat() if row[19] else None,
-                "version_count": row[20],
+                "duplicate_status": row[20],
+                "related_report_id": row[21],
+                "version_count": row[22],
             },
         })
 

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -1,6 +1,6 @@
 import os
 import uuid
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import boto3
 import h3
@@ -110,7 +110,7 @@ def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> di
         
         # Check 2: Same location + recent (within 2 minutes, 15m radius)
         # This catches accidental double-submits
-        time_threshold = datetime.now(datetime.timezone.utc) - timedelta(seconds=DUPLICATE_TIME_WINDOW_SECONDS)
+        time_threshold = datetime.now(timezone.utc) - timedelta(seconds=DUPLICATE_TIME_WINDOW_SECONDS)
         cur.execute(
             f"""
             SELECT id FROM reports

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -77,16 +77,16 @@ class ReportsQueryParams(BaseModel):
 def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> dict:
     """
     Check for duplicate or reassessment reports.
-    
+
     Returns dict with keys:
     - duplicate_status: None | 'possible_duplicate' | 'reassessment'
     - related_report_id: UUID of related report (if any)
-    
+
     Logic:
     1. If same building_id → reassessment (intentional re-assessment)
     2. Else if same location + recent → possible_duplicate (accidental double-submit)
     3. Else → no flag
-    
+
     Note: reassessment takes precedence over duplicate (building_id is explicit intent).
     """
     with conn.cursor() as cur:
@@ -107,7 +107,7 @@ def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> di
                     "duplicate_status": "reassessment",
                     "related_report_id": str(result[0]),
                 }
-        
+
         # Check 2: Same location + recent (within 2 minutes, 15m radius)
         # This catches accidental double-submits
         time_threshold = datetime.now(timezone.utc) - timedelta(seconds=DUPLICATE_TIME_WINDOW_SECONDS)
@@ -131,7 +131,7 @@ def _check_for_duplicates(conn, submission: ReportSubmission, h3_r12: str) -> di
                 "duplicate_status": "possible_duplicate",
                 "related_report_id": str(result[0]),
             }
-    
+
     return {"duplicate_status": None, "related_report_id": None}
 
 

--- a/backend/tests/test_duplicate_detection.py
+++ b/backend/tests/test_duplicate_detection.py
@@ -35,11 +35,11 @@ class TestDuplicateDetection:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         
-        # First query (for building_id check) returns None
-        # Second query (for location/time check) returns Report A
-        # Third query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
-        
+        # building_id is None so the building check is skipped entirely
+        # First query (location/time check) returns Report A
+        # Second query (area count) returns 1
+        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -111,11 +111,11 @@ class TestDuplicateDetection:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         
-        # First query (for building_id check) returns None
-        # Second query (for location/time check) returns None
-        # Third query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, None, (1,)]
-        
+        # building_id is None so the building check is skipped entirely
+        # First query (location/time check) returns None — far enough away
+        # Second query (area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -136,11 +136,11 @@ class TestDuplicateDetection:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         
-        # First query (for building_id check) returns None
-        # Second query (for location/time check) returns None (time window excluded it)
-        # Third query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, None, (1,)]
-        
+        # building_id is None so the building check is skipped entirely
+        # First query (location/time check) returns None — outside time window
+        # Second query (area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -161,10 +161,10 @@ class TestDuplicateDetection:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         
-        # First query (for building_id check) returns None
-        # Second query (for location/time check) returns None (distance excludes it)
-        # Third query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, None, (1,)]
+        # building_id is None so the building check is skipped entirely
+        # First query (location/time check) returns None — outside distance threshold
+        # Second query (area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, (1,)]
         
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -188,10 +188,10 @@ class TestDuplicateDetection:
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
         
-        # First query (for building_id check, building_id is None) returns None
-        # Second query (for location/time check) returns Report A
-        # Third query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+        # building_id is None so the building check is skipped entirely
+        # First query (location/time check) returns Report A
+        # Second query (area count) returns 1
+        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
         
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)

--- a/backend/tests/test_duplicate_detection.py
+++ b/backend/tests/test_duplicate_detection.py
@@ -1,0 +1,224 @@
+import uuid
+from datetime import datetime, timedelta, timezone
+from unittest.mock import MagicMock, patch
+
+from src.handlers.reports import create_report
+
+
+def _valid_body(**overrides):
+    base = {
+        "latitude": 51.5074,
+        "longitude": -0.1278,
+        "building_id": None,
+        "damage_level": "partial",
+        "infrastructure_type": ["Residential Infrastructure (Houses and apartments)"],
+        "crisis_nature": ["Earthquake"],
+        "debris_present": True,
+        "electricity_status": "Minor damage (service disruptions but quickly repairable)",
+        "health_status": "Partially functional",
+        "pressing_needs": ["Food assistance and safe drinking water"],
+    }
+    base.update(overrides)
+    return base
+
+
+class TestDuplicateDetection:
+    """Test duplicate and reassessment detection logic."""
+
+    @patch("src.handlers.reports.get_connection")
+    def test_same_location_and_recent_time_flagged_as_duplicate(self, mock_get_conn):
+        """
+        Report A: submitted at T=0, lat=51.5074, lng=-0.1278
+        Report B: submitted at T=30 seconds, same location
+        Expected: Report B flagged as "possible_duplicate" with related_report_id = A
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns None
+        # Second query (for location/time check) returns Report A
+        # Third query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body())
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] == "possible_duplicate"
+        assert result["related_report_id"] == "report-a-id"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_same_building_flagged_as_reassessment(self, mock_get_conn):
+        """
+        Report A: submitted for building X
+        Report B: submitted for same building X
+        Expected: Report B flagged as "reassessment" with related_report_id = A
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns Report A
+        # Second query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body(building_id="building-123"))
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] == "reassessment"
+        assert result["related_report_id"] == "report-a-id"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_reassessment_overrides_duplicate(self, mock_get_conn):
+        """
+        Report A: submitted for building X at location L, time T=0
+        Report B: submitted for same building X, same location L, time T=30s
+        Expected: Report B flagged as "reassessment" (building_id match takes precedence)
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns Report A
+        # Second query (for area count) returns 1
+        # Note: location/time check never runs because building_id match found first
+        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(
+            _valid_body(building_id="building-123", latitude=51.5074, longitude=-0.1278)
+        )
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] == "reassessment"
+        assert result["related_report_id"] == "report-a-id"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_different_location_no_flag(self, mock_get_conn):
+        """
+        Report A: submitted at location L1 (lat=51.5, lng=-0.1)
+        Report B: submitted at different location L2 (lat=52.0, lng=0.0) - far away
+        Expected: Report B has no duplicate_status
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns None
+        # Second query (for location/time check) returns None
+        # Third query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body(latitude=52.0, longitude=0.0))
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] is None
+        assert result["related_report_id"] is None
+
+    @patch("src.handlers.reports.get_connection")
+    def test_outside_time_window_no_flag(self, mock_get_conn):
+        """
+        Report A: submitted at T=0 at location L
+        Report B: submitted at T=150 seconds (2.5 minutes) at same location L
+        Expected: Report B has no duplicate_status (outside 2-minute window)
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns None
+        # Second query (for location/time check) returns None (time window excluded it)
+        # Third query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body())
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] is None
+        assert result["related_report_id"] is None
+
+    @patch("src.handlers.reports.get_connection")
+    def test_outside_distance_threshold_no_flag(self, mock_get_conn):
+        """
+        Report A: submitted at location L (lat=51.5074, lng=-0.1278)
+        Report B: submitted at T=30 seconds, but ~50m away
+        Expected: Report B has no duplicate_status (outside 15m radius)
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check) returns None
+        # Second query (for location/time check) returns None (distance excludes it)
+        # Third query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(
+            _valid_body(latitude=51.5074 + 0.0005, longitude=-0.1278 + 0.0005)  # ~50m away
+        )
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] is None
+        assert result["related_report_id"] is None
+
+    @patch("src.handlers.reports.get_connection")
+    def test_no_building_id_still_checks_location(self, mock_get_conn):
+        """
+        Report A: manual pin (building_id=None) at location L, time T=0
+        Report B: manual pin (building_id=None) at same location L, time T=30s
+        Expected: Report B flagged as "possible_duplicate" (location/time check applies)
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        
+        # First query (for building_id check, building_id is None) returns None
+        # Second query (for location/time check) returns Report A
+        # Third query (for area count) returns 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body(building_id=None))
+
+        assert result["status"] == "created"
+        assert result["duplicate_status"] == "possible_duplicate"
+        assert result["related_report_id"] == "report-a-id"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_duplicate_fields_in_api_response(self, mock_get_conn):
+        """
+        Verify that duplicate_status and related_report_id are included in API response.
+        """
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchone.side_effect = [("report-a-id",), (5,)]
+        
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = create_report(_valid_body(building_id="building-x"))
+
+        assert "duplicate_status" in result
+        assert "related_report_id" in result
+        assert result["duplicate_status"] == "reassessment"
+        assert result["related_report_id"] == "report-a-id"

--- a/backend/tests/test_duplicate_detection.py
+++ b/backend/tests/test_duplicate_detection.py
@@ -34,11 +34,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # building_id is None so the building check is skipped entirely
-        # First query (location/time check) returns Report A
-        # Second query (area count) returns 1
-        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
+
+        # building_id is None so building check is skipped
+        # _find_version_chain (h3 lookup) → None (new chain)
+        # location/time check → Report A
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
 
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -59,11 +60,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # First query (for building_id check) returns Report A
-        # Second query (for area count) returns 1
-        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
-        
+
+        # _find_version_chain (building lookup) → None (new chain)
+        # building check → Report A (reassessment, returns immediately)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -83,12 +85,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # First query (for building_id check) returns Report A
-        # Second query (for area count) returns 1
-        # Note: location/time check never runs because building_id match found first
-        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
-        
+
+        # _find_version_chain (building lookup) → None (new chain)
+        # building check → Report A (reassessment, returns immediately — location check skipped)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -110,11 +112,11 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # building_id is None so the building check is skipped entirely
-        # First query (location/time check) returns None — far enough away
-        # Second query (area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, (1,)]
+
+        # _find_version_chain (h3 lookup) → None (new chain)
+        # location/time check → None (far enough away)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
 
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -135,11 +137,11 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # building_id is None so the building check is skipped entirely
-        # First query (location/time check) returns None — outside time window
-        # Second query (area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, (1,)]
+
+        # _find_version_chain (h3 lookup) → None (new chain)
+        # location/time check → None (outside time window)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
 
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
@@ -160,12 +162,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # building_id is None so the building check is skipped entirely
-        # First query (location/time check) returns None — outside distance threshold
-        # Second query (area count) returns 1
-        mock_cursor.fetchone.side_effect = [None, (1,)]
-        
+
+        # _find_version_chain (h3 lookup) → None (new chain)
+        # location/time check → None (outside distance threshold)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, None, (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -187,12 +189,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        
-        # building_id is None so the building check is skipped entirely
-        # First query (location/time check) returns Report A
-        # Second query (area count) returns 1
-        mock_cursor.fetchone.side_effect = [("report-a-id",), (1,)]
-        
+
+        # _find_version_chain (h3 lookup) → None (new chain)
+        # location/time check → Report A
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (1,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -210,8 +212,12 @@ class TestDuplicateDetection:
         """
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.side_effect = [("report-a-id",), (5,)]
-        
+
+        # _find_version_chain (building lookup) → None (new chain)
+        # building check → Report A (reassessment)
+        # area count → 5
+        mock_cursor.fetchone.side_effect = [None, ("report-a-id",), (5,)]
+
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -95,7 +95,11 @@ class TestCreateReport:
     def test_creates_report(self, mock_get_conn):
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.side_effect = [None, (1,)]
+        # _find_version_chain (building lookup) → None (new chain)
+        # duplicate building check → None (no reassessment)
+        # duplicate location check → None (no duplicate)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, None, None, (1,)]
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -127,7 +131,11 @@ class TestCreateReport:
     def test_includes_photo_url_when_key_provided(self, mock_get_conn):
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        mock_cursor.fetchone.side_effect = [None, (1,)]
+        # _find_version_chain (building lookup) → None (new chain)
+        # duplicate building check → None (no reassessment)
+        # duplicate location check → None (no duplicate)
+        # area count → 1
+        mock_cursor.fetchone.side_effect = [None, None, None, (1,)]
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -158,6 +166,7 @@ class TestQueryReports:
                 None, ["Food assistance and safe drinking water"],
                 "chain-id-1", True,
                 datetime(2026, 4, 17, tzinfo=timezone.utc),
+                None, None,  # duplicate_status, related_report_id
                 1,
             )
         ]

--- a/db/008_add_duplicate_detection.sql
+++ b/db/008_add_duplicate_detection.sql
@@ -1,0 +1,10 @@
+-- Add duplicate and reassessment detection fields
+ALTER TABLE reports ADD COLUMN duplicate_status TEXT;
+ALTER TABLE reports ADD COLUMN related_report_id UUID REFERENCES reports(id);
+
+-- Create indexes for efficient querying
+CREATE INDEX idx_reports_duplicate_status ON reports(duplicate_status);
+CREATE INDEX idx_reports_related_report ON reports(related_report_id);
+
+-- Create index on (submitted_at, location) for duplicate detection queries
+CREATE INDEX idx_reports_submitted_location ON reports(submitted_at, location);

--- a/db/008_add_duplicate_detection.sql
+++ b/db/008_add_duplicate_detection.sql
@@ -6,3 +6,5 @@ ALTER TABLE reports ADD COLUMN related_report_id UUID REFERENCES reports(id);
 CREATE INDEX idx_reports_duplicate_status ON reports(duplicate_status);
 CREATE INDEX idx_reports_related_report ON reports(related_report_id);
 
+ALTER TABLE reports ADD CONSTRAINT duplicate_status_valid
+  CHECK (duplicate_status IS NULL OR duplicate_status IN ('possible_duplicate', 'reassessment'));

--- a/db/008_add_duplicate_detection.sql
+++ b/db/008_add_duplicate_detection.sql
@@ -6,5 +6,3 @@ ALTER TABLE reports ADD COLUMN related_report_id UUID REFERENCES reports(id);
 CREATE INDEX idx_reports_duplicate_status ON reports(duplicate_status);
 CREATE INDEX idx_reports_related_report ON reports(related_report_id);
 
--- Create index on (submitted_at, location) for duplicate detection queries
-CREATE INDEX idx_reports_submitted_location ON reports(submitted_at, location);


### PR DESCRIPTION
## Summary

- Adds `duplicate_status` and `related_report_id` columns to the reports table (migration `008_add_duplicate_detection.sql`)
- Detects same-location duplicates within 15m / 2 minutes
- Detects reassessments when the same `building_id` is submitted again (overrides duplicate status)
- Returns `duplicate_status` and `related_report_id` flags in the `POST /reports` response
- Comprehensive test coverage for all scenarios

Closes #54

## Test plan

- [ ] Run `pytest backend/tests/test_duplicate_detection.py`  
- [ ] Submit a report, then submit another at the same location within 2 min ? expect `duplicate` status
- [ ] Submit a report for the same building again ? expect `reassessment` status
- [ ] Submit a report at a different location ? expect no duplicate flags