### PR TITLE
feat: polished deployment poster with crisis icons and 3-step guide (#167)

### DIFF
--- a/frontend/src/assets/poster-icons.ts
+++ b/frontend/src/assets/poster-icons.ts
@@ -1,0 +1,105 @@
+// SVG icon strings for the printable deployment poster.
+// All icons use currentColor so they inherit colour from their container.
+
+export const ICON_SCAN = `<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="5" y="5" width="15" height="15" rx="1.5" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <rect x="9" y="9" width="7" height="7" fill="currentColor"/>
+  <rect x="28" y="5" width="15" height="15" rx="1.5" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <rect x="32" y="9" width="7" height="7" fill="currentColor"/>
+  <rect x="5" y="28" width="15" height="15" rx="1.5" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <rect x="9" y="32" width="7" height="7" fill="currentColor"/>
+  <rect x="28" y="28" width="4" height="4" fill="currentColor"/>
+  <rect x="35" y="28" width="4" height="4" fill="currentColor"/>
+  <rect x="28" y="35" width="4" height="4" fill="currentColor"/>
+  <rect x="35" y="35" width="4" height="4" fill="currentColor"/>
+  <rect x="42" y="28" width="1.5" height="1.5" fill="currentColor"/>
+  <rect x="42" y="33" width="1.5" height="1.5" fill="currentColor"/>
+  <rect x="42" y="38" width="1.5" height="1.5" fill="currentColor"/>
+  <rect x="42" y="43" width="1.5" height="1.5" fill="currentColor"/>
+</svg>`;
+
+export const ICON_CAMERA = `<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <rect x="4" y="16" width="40" height="27" rx="4" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <path d="M16 16 L19 9 H29 L32 16" stroke="currentColor" stroke-width="2.5" stroke-linejoin="round" fill="none"/>
+  <circle cx="24" cy="29" r="8" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <circle cx="24" cy="29" r="3.5" fill="currentColor"/>
+  <circle cx="36" cy="22" r="2" fill="currentColor"/>
+</svg>`;
+
+export const ICON_SUBMIT = `<svg viewBox="0 0 48 48" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="24" cy="24" r="20" stroke="currentColor" stroke-width="2.5" fill="none"/>
+  <line x1="24" y1="33" x2="24" y2="17" stroke="currentColor" stroke-width="2.5" stroke-linecap="round"/>
+  <polyline points="15,24 24,15 33,24" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" fill="none"/>
+</svg>`;
+
+// Crisis-type icons. Designed at 24×24 viewBox, minimal stroke style.
+const crisisIconMap: Record<string, string> = {
+  Earthquake: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 14 L6 9 L10 17 L14 7 L18 15 L22 11" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <line x1="2" y1="19" x2="22" y2="19" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.4"/>
+  </svg>`,
+
+  Flood: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 10 Q5.5 7 9 10 Q12.5 13 16 10 Q19.5 7 22 10" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M2 16 Q5.5 13 9 16 Q12.5 19 16 16 Q19.5 13 22 16" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M7 4 L9 7 M12 3 L12 6 M17 4 L15 7" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.6"/>
+  </svg>`,
+
+  Tsunami: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M2 17 Q5 14 8 14 Q11 14 12 11 Q13 7 10 5 Q15 5 17 10 Q19 14 16 17 H22" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <path d="M2 21 Q7 19 12 21 Q17 23 22 21" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" opacity="0.5"/>
+  </svg>`,
+
+  "Hurricane/Cyclone": `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M20 8 C20 8 22 11 20 14 C18 17 14 18 12 16 C10 14 11 11 13 10 C15 9 17 10 16 12 C15 14 12 14 12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <path d="M4 16 C4 16 2 13 4 10 C6 7 10 6 12 8 C14 10 13 13 11 14 C9 15 7 14 8 12 C9 10 12 10 12 12" stroke="currentColor" stroke-width="2" stroke-linecap="round" fill="none"/>
+    <circle cx="12" cy="12" r="1.5" fill="currentColor"/>
+  </svg>`,
+
+  Wildfire: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 21 C8 21 5 18 5 14 C5 11 7 9 8 8 C8 10 10 11 10 11 C9 9 10 6 12 4 C12 7 14 8 15 10 C16 9 16 7 15 5 C18 8 19 12 19 14 C19 18 16 21 12 21 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" fill="none"/>
+    <path d="M12 21 C10 21 9 19 9 17 C9 15 10.5 14 11 14 C11 15 12 15.5 12 15.5 C12 15.5 13 15 13 14 C14 15 15 16 15 17 C15 19 14 21 12 21 Z" fill="currentColor" opacity="0.3"/>
+  </svg>`,
+
+  Explosion: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <circle cx="12" cy="12" r="3.5" fill="currentColor" opacity="0.2" stroke="currentColor" stroke-width="1.5"/>
+    <line x1="12" y1="2" x2="12" y2="6.5" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="12" y1="17.5" x2="12" y2="22" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="2" y1="12" x2="6.5" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="17.5" y1="12" x2="22" y2="12" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="4.9" y1="4.9" x2="8.1" y2="8.1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="15.9" y1="15.9" x2="19.1" y2="19.1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="19.1" y1="4.9" x2="15.9" y2="8.1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <line x1="8.1" y1="15.9" x2="4.9" y2="19.1" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  </svg>`,
+
+  "Chemical incident": `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M9 3 H15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <path d="M10 3 L7 9 C5 12 5 17 8 20 C9 21 10.5 22 12 22 C13.5 22 15 21 16 20 C19 17 19 12 17 9 L14 3" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round"/>
+    <circle cx="10" cy="16" r="1.5" fill="currentColor"/>
+    <circle cx="14.5" cy="13" r="1" fill="currentColor"/>
+    <circle cx="11" cy="12" r="0.75" fill="currentColor"/>
+  </svg>`,
+
+  Conflict: `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 3 L21.5 20 H2.5 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" fill="none"/>
+    <line x1="12" y1="10" x2="12" y2="15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="12" cy="18.5" r="1.25" fill="currentColor"/>
+  </svg>`,
+
+  "Civil unrest": `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+    <path d="M12 3 L21.5 20 H2.5 Z" stroke="currentColor" stroke-width="2" stroke-linejoin="round" fill="none"/>
+    <line x1="12" y1="10" x2="12" y2="15" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+    <circle cx="12" cy="18.5" r="1.25" fill="currentColor"/>
+  </svg>`,
+};
+
+const FALLBACK_ICON = `<svg viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <circle cx="12" cy="12" r="9" stroke="currentColor" stroke-width="2" fill="none"/>
+  <line x1="12" y1="8" x2="12" y2="13" stroke="currentColor" stroke-width="2" stroke-linecap="round"/>
+  <circle cx="12" cy="16.5" r="1.25" fill="currentColor"/>
+</svg>`;
+
+export function getCrisisIcon(crisisType: string): string {
+  return crisisIconMap[crisisType] ?? FALLBACK_ICON;
+}

--- a/frontend/src/components/activation-kit-modal.tsx
+++ b/frontend/src/components/activation-kit-modal.tsx
@@ -1,6 +1,7 @@
 import { useRef, useState } from "react";
 import { QRCodeSVG } from "qrcode.react";
 import { X, Copy, Check, Printer } from "lucide-react";
+import { ICON_SCAN, ICON_CAMERA, ICON_SUBMIT, getCrisisIcon } from "../assets/poster-icons";
 import styles from "./activation-kit-modal.module.css";
 
 interface CrisisEvent {
@@ -82,9 +83,10 @@ export function ActivationKitModal({ crisis, onClose }: Props) {
   const handlePrint = () => {
     const svgEl = qrRef.current?.querySelector("svg");
     const svgString = svgEl ? svgEl.outerHTML : "";
+    const crisisIconSvg = getCrisisIcon(crisis.crisis_type);
 
     const instructions = Object.entries(POSTER_INSTRUCTIONS)
-      .map(([, text]) => `<p>${text}</p>`)
+      .map(([, text]) => `<p class="instruction">${text}</p>`)
       .join("");
 
     const html = `<!DOCTYPE html>
@@ -93,96 +95,96 @@ export function ActivationKitModal({ crisis, onClose }: Props) {
 <meta charset="UTF-8" />
 <title>TERRA — ${escapeHtml(crisis.name)}</title>
 <style>
+  @page { size: A4 portrait; margin: 0; }
   * { margin: 0; padding: 0; box-sizing: border-box; }
-  body {
-    font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;
-    background: #fff;
-    color: #111;
-    padding: 48px 56px;
-  }
-  .top-bar {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    border-bottom: 3px solid #0468b1;
-    padding-bottom: 16px;
-    margin-bottom: 28px;
-  }
-  .terra-name {
-    font-size: 2rem;
-    font-weight: 900;
-    letter-spacing: 0.08em;
-    color: #0468b1;
-  }
-  .undp-label {
-    font-size: 0.75rem;
-    color: #666;
-    text-transform: uppercase;
-    letter-spacing: 0.06em;
-  }
-  .crisis-name {
-    font-size: 1.75rem;
-    font-weight: 700;
-    margin-bottom: 4px;
-  }
-  .crisis-type {
-    font-size: 0.9rem;
-    color: #555;
-    text-transform: uppercase;
-    letter-spacing: 0.05em;
-    margin-bottom: 36px;
-  }
-  .qr-section {
-    display: flex;
-    flex-direction: column;
-    align-items: center;
-    margin: 0 auto 32px;
-    width: fit-content;
-  }
-  .qr-section svg {
-    display: block;
-    width: 200px !important;
-    height: 200px !important;
-  }
-  .instructions {
-    margin-top: 16px;
-    text-align: center;
-    font-size: 0.8rem;
-    color: #444;
-    line-height: 1.6;
-  }
-  .url-box {
-    margin-top: 24px;
-    border: 1px solid #ccc;
-    padding: 10px 16px;
-    font-size: 0.85rem;
-    color: #333;
-    text-align: center;
-    word-break: break-all;
-  }
-  .footer {
-    margin-top: 48px;
-    border-top: 1px solid #ddd;
-    padding-top: 14px;
-    font-size: 0.7rem;
-    color: #999;
-    text-align: center;
-  }
+  body { font-family: "Helvetica Neue", Helvetica, Arial, sans-serif; background: #fff; color: #111827; }
+
+  .header { background: #0468b1; padding: 20px 40px; display: flex; align-items: center; justify-content: space-between; }
+  .terra-logo { font-size: 26px; font-weight: 900; letter-spacing: 0.1em; color: #fff; }
+  .terra-sub { font-size: 9px; color: rgba(255,255,255,0.7); text-transform: uppercase; letter-spacing: 0.1em; margin-top: 3px; }
+
+  .crisis-section { padding: 22px 40px 18px; border-bottom: 1px solid #e5e7eb; display: flex; align-items: center; gap: 14px; }
+  .crisis-icon { width: 32px; height: 32px; color: #0468b1; flex-shrink: 0; }
+  .crisis-icon svg { width: 100%; height: 100%; display: block; }
+  .crisis-name { font-size: 26px; font-weight: 700; color: #111827; letter-spacing: -0.01em; line-height: 1.2; }
+  .crisis-type-label { font-size: 11px; font-weight: 600; color: #0468b1; text-transform: uppercase; letter-spacing: 0.07em; margin-top: 3px; }
+
+  .steps-section { padding: 20px 40px; border-bottom: 1px solid #e5e7eb; }
+  .steps-heading { font-size: 9px; font-weight: 700; text-transform: uppercase; letter-spacing: 0.12em; color: #9ca3af; margin-bottom: 16px; }
+  .steps-row { display: flex; align-items: center; }
+  .step { flex: 1; display: flex; flex-direction: column; align-items: center; gap: 7px; }
+  .step-icon { width: 44px; height: 44px; color: #0468b1; }
+  .step-icon svg { width: 100%; height: 100%; display: block; }
+  .step-num { width: 20px; height: 20px; background: #0468b1; border-radius: 50%; color: #fff; font-size: 11px; font-weight: 700; display: flex; align-items: center; justify-content: center; }
+  .step-label { font-size: 10px; font-weight: 700; color: #374151; text-transform: uppercase; letter-spacing: 0.06em; }
+  .step-arrow { color: #d1d5db; font-size: 22px; font-weight: 200; padding: 0 4px; padding-bottom: 24px; }
+
+  .qr-section { padding: 28px 40px 24px; display: flex; flex-direction: column; align-items: center; gap: 16px; border-bottom: 1px solid #e5e7eb; }
+  .qr-frame { padding: 12px; border: 1.5px solid #e5e7eb; display: inline-block; }
+  .qr-frame svg { display: block; width: 180px !important; height: 180px !important; }
+  .instructions { text-align: center; }
+  .instruction { font-size: 11px; color: #6b7280; line-height: 1.6; }
+
+  .url-section { padding: 16px 40px 20px; }
+  .url-box { background: #f9fafb; border: 1px solid #e5e7eb; padding: 9px 16px; text-align: center; font-family: "Courier New", monospace; font-size: 12px; color: #374151; letter-spacing: 0.02em; word-break: break-all; }
+
+  .footer { padding: 12px 40px; border-top: 1px solid #e5e7eb; display: flex; justify-content: space-between; align-items: center; }
+  .footer-text { font-size: 8px; color: #9ca3af; text-transform: uppercase; letter-spacing: 0.07em; }
 </style>
 </head>
 <body>
-  <div class="top-bar">
-    <span class="terra-name">TERRA</span>
-    <span class="undp-label">Crisis Damage Assessment · UNDP RAPIDA</span>
+  <div class="header">
+    <div>
+      <div class="terra-logo">TERRA</div>
+      <div class="terra-sub">RAPIDA · Crisis Damage Assessment</div>
+    </div>
   </div>
-  <div class="crisis-name">${escapeHtml(crisis.name)}</div>
-  <div class="crisis-type">${escapeHtml(crisis.crisis_type)}</div>
+
+  <div class="crisis-section">
+    <div class="crisis-icon">${crisisIconSvg}</div>
+    <div>
+      <div class="crisis-name">${escapeHtml(crisis.name)}</div>
+      <div class="crisis-type-label">${escapeHtml(crisis.crisis_type)}</div>
+    </div>
+  </div>
+
+  <div class="steps-section">
+    <div class="steps-heading">How to submit a report</div>
+    <div class="steps-row">
+      <div class="step">
+        <div class="step-icon">${ICON_SCAN}</div>
+        <div class="step-num">1</div>
+        <div class="step-label">Scan</div>
+      </div>
+      <div class="step-arrow">&#8594;</div>
+      <div class="step">
+        <div class="step-icon">${ICON_CAMERA}</div>
+        <div class="step-num">2</div>
+        <div class="step-label">Photograph</div>
+      </div>
+      <div class="step-arrow">&#8594;</div>
+      <div class="step">
+        <div class="step-icon">${ICON_SUBMIT}</div>
+        <div class="step-num">3</div>
+        <div class="step-label">Submit</div>
+      </div>
+    </div>
+  </div>
+
   <div class="qr-section">
-    ${svgString}
+    <div class="qr-frame">${svgString}</div>
     <div class="instructions">${instructions}</div>
   </div>
-  <div class="url-box">${url}</div>
-  <div class="footer">Generated by TERRA · Tool for Early Reporting and Rapid Assessment</div>
+
+  <div class="url-section">
+    <div class="url-box">${url}</div>
+  </div>
+
+  <div class="footer">
+    <span class="footer-text">TERRA · Tool for Early Reporting and Rapid Assessment</span>
+    <span class="footer-text">Field deployment material · UNDP RAPIDA</span>
+  </div>
+
   <script>window.addEventListener('load', function() { window.print(); });</script>
 </body>
 </html>`;


### PR DESCRIPTION
## What was built

Redesigns the printable A4 deployment poster generated by the Community Activation Kit (`handlePrint()` in `activation-kit-modal.tsx`).

The original MVP was a plain-text layout. This replaces it with a structured, field-quality design suitable for physical distribution.

### New poster layout

- **Blue UNDP-style header** — TERRA wordmark + "RAPIDA · Crisis Damage Assessment" subtitle
- **Crisis section** — crisis-type icon (unique per type) + crisis name + type label
- **3-step visual guide** — "How to submit a report" with inline SVG pictograms (Scan → Photograph → Submit) above numbered circles and step labels
- **QR code** — framed with border, instructions printed below in all 6 UN languages
- **URL box** — monospace, light background, full submission URL
- **Footer** — TERRA attribution + "Field deployment material · UNDP RAPIDA"

### New file: `frontend/src/assets/poster-icons.ts`

All icons authored as inline SVG strings using `currentColor` — no external image assets, no CDN references, everything embeds into the generated print window HTML.

- `ICON_SCAN` — QR code pattern (three corner markers + data dots)
- `ICON_CAMERA` — camera body, viewfinder bump, lens, flash indicator
- `ICON_SUBMIT` — circle with upward arrow
- `getCrisisIcon(crisisType)` — maps 9 crisis types to unique icons: Earthquake (seismic wave), Flood (waves + rain), Tsunami (curl wave), Hurricane/Cyclone (dual spiral), Wildfire (flame), Explosion (radial lines), Chemical incident (flask + bubbles), Conflict (warning triangle), Civil unrest (warning triangle); generic info-circle fallback for unknown types

### Scope decisions

- External image generation was considered and ruled out — inline SVG is more reliable in print popups (no cross-origin, no CDN dependency, works offline), which aligns with TERRA's offline-first principle
- Icons are intentionally minimal/stroke-weight to keep the poster readable at A4 printed size
- Conflict and Civil unrest share the same warning-triangle icon deliberately — they're visually similar threat types and the crisis name above distinguishes them

### What was not changed

The modal UI in the app is unchanged. Only the print output (`handlePrint()`) is modified. All existing WhatsApp template and QR generation logic is untouched.

Closes #167