### PR TITLE
feat: auto-centre community map on active crisis zone (#195)

### DIFF
--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -2,6 +2,7 @@ import { useRef, useEffect } from "react";
 import maplibregl from "maplibre-gl";
 import "maplibre-gl/dist/maplibre-gl.css";
 import { Protocol } from "pmtiles";
+import { api } from "../utils/api";
 import styles from "./map.module.css";
 
 const VIDA_BUILDINGS_URL =
@@ -237,6 +238,45 @@ export const Map = ({
       markerRef.current = null;
       pinMarkerRef.current = null;
       hasCenteredRef.current = false;
+    };
+  }, []);
+
+  // Fit the initial view to the active crisis zone(s) instead of the world
+  // view, so QR/demo links land directly on the affected area (#195). A
+  // geolocation fix takes precedence: it recentres on the user when it
+  // arrives, and once it has, the crisis fit is skipped.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    let cancelled = false;
+    (async () => {
+      try {
+        const data = await api("/crisis-events");
+        if (cancelled || hasCenteredRef.current) return;
+        const active = (data?.events ?? []).filter(
+          (e: { is_active: boolean }) => e.is_active,
+        );
+        if (active.length === 0) return;
+        const bounds = new maplibregl.LngLatBounds();
+        const extend = (coords: unknown) => {
+          if (!Array.isArray(coords)) return;
+          if (typeof coords[0] === "number") {
+            bounds.extend(coords as [number, number]);
+          } else {
+            for (const c of coords) extend(c);
+          }
+        };
+        for (const e of active) extend(e.region?.coordinates);
+        if (!bounds.isEmpty() && !hasCenteredRef.current) {
+          map.fitBounds(bounds, { padding: 60, animate: false });
+        }
+      } catch {
+        // No crisis info available — keep the default view until the
+        // geolocation fix arrives.
+      }
+    })();
+    return () => {
+      cancelled = true;
     };
   }, []);
 


### PR DESCRIPTION
## What was built

On PWA load, the community map now fits the viewport to the bounding box of all active crisis zones instead of opening on the world view (Atlantic Ocean at zoom 2).

## Why this scope

The default world view meant evaluators and community members landing via QR code had no immediate visual anchor — they'd need to manually navigate to the crisis area. This is a self-contained fix with no schema or backend changes.

## Behaviour

- Fetches `GET /crisis-events` on mount, filters to `is_active: true`, unions the region polygon bounding boxes, and calls `fitBounds` with 60px padding
- Uses `animate: false` — the snap happens before the user sees anything, so no jarring fly-in on load
- **Geolocation takes precedence:** `hasCenteredRef` gates both effects. The crisis fit does not set the flag; geolocation does. So if a GPS fix arrives after the crisis fit, the map flies to the user's position as before. If geolocation fires first, the crisis fit is skipped entirely
- Silent fallback: if the API is unreachable or returns no active crises, the existing default view is kept — no broken state

## What was deferred

Geolocation-denied + no active crises still opens on the world view. A static fallback coordinate for the default crisis area could be added, but requires a config change and is out of scope here.

Closes #195