### PR TITLE
feat: scale-test generator and timed query set for 500k reports

### DIFF
--- a/db/generate_scale_test.py
+++ b/db/generate_scale_test.py
@@ -1,0 +1,130 @@
+"""Generate synthetic reports at scale (default 500k) as CSV for COPY.
+
+The challenge brief's scale targets are 50k (local), 250k (regional) and
+500k (national) reports per crisis. This produces a CSV that loads in
+minutes via COPY — INSERT statements do not scale to these row counts.
+
+Usage:
+    python generate_scale_test.py --rows 500000
+    # then, against a DISPOSABLE test instance (never the demo DB):
+    #   \\copy reports (id, location, h3_r12, h3_r8, building_id,
+    #       damage_level, infrastructure_type, infrastructure_description,
+    #       crisis_nature, debris_present, electricity_status,
+    #       health_status, pressing_needs, version_chain_id,
+    #       is_latest, device_id, submitted_at)
+    #       FROM 'scale_test_reports.csv' WITH (FORMAT csv)
+    # then run scale_test_queries.sql with \\timing on.
+
+Teardown: DELETE FROM reports WHERE device_id LIKE 'device-scale-%';
+"""
+
+import argparse
+import csv
+import math
+import random
+import uuid
+from datetime import datetime, timedelta
+
+import h3
+
+# Same Hatay geography and severity-zone shape as the demo seed so the
+# dashboard looks plausible at any zoom; distinct device prefix so the two
+# datasets can never be confused.
+BBOX = {"west": 36.10, "east": 36.22, "south": 36.17, "north": 36.25}
+EPICENTRE = (36.16, 36.21)
+ZONES = {
+    "centre": (0.40, 0.012, [0.10, 0.20, 0.70]),
+    "ring": (0.35, 0.030, [0.20, 0.60, 0.20]),
+    "periphery": (0.25, 0.055, [0.70, 0.20, 0.10]),
+}
+DAMAGE_LEVELS = ["minimal", "partial", "complete"]
+
+INFRASTRUCTURE_TYPES = [
+    "Residential Infrastructure (Houses and apartments)",
+    "Commercial Infrastructure (Markets, malls, shops, hotels, banks, industries, etc.)",
+    "Government Building (Administrative buildings, courthouses, police stations, fire stations, etc.)",
+    "Utility Infrastructure (Water pumps, power plants, waste treatment plants, etc.)",
+    "Transport and Communication Infrastructure (Roads, cell towers, bridges, railway station, bus station, etc.)",
+    "Community Infrastructure (Schools, hospitals, community halls, public toilets, etc.)",
+    "Public spaces/Recreation Infrastructure (stadiums, playgrounds, religious buildings, etc.)",
+]
+INFRA_WEIGHTS = [0.35, 0.15, 0.1, 0.1, 0.1, 0.1, 0.1]
+
+ELECTRICITY = [
+    "No damage observed",
+    "Moderate damage (partial outages requiring repairs)",
+    "Severe damage (major infrastructure damaged, prolonged outages)",
+]
+HEALTH = ["Fully functional", "Partially functional", "Largely disrupted"]
+NEEDS = [
+    "Food assistance and safe drinking water",
+    "Shelter, housing repair, or temporary accommodation",
+    "Restoration of basic services and infrastructure (electricity, roads, schools)",
+]
+
+BASE_TIME = datetime(2026, 4, 5, 8, 0, 0)
+random.seed(0x5CA1E)
+
+
+def pg_array(items):
+    return "{" + ",".join('"' + i.replace('"', '\\"') + '"' for i in items) + "}"
+
+
+def generate(path: str, rows: int) -> None:
+    zone_names = list(ZONES)
+    zone_shares = [ZONES[n][0] for n in zone_names]
+
+    with open(path, "w", newline="", encoding="utf-8") as f:
+        writer = csv.writer(f)
+        for i in range(rows):
+            zone = random.choices(zone_names, weights=zone_shares, k=1)[0]
+            zone_idx = zone_names.index(zone)
+            inner = 0.0 if zone_idx == 0 else ZONES[zone_names[zone_idx - 1]][1]
+            outer = ZONES[zone][1]
+            angle = random.uniform(0, 2 * math.pi)
+            radius = random.uniform(inner, outer)
+            lng = min(BBOX["east"], max(BBOX["west"], EPICENTRE[0] + radius * math.cos(angle)))
+            lat = min(BBOX["north"], max(BBOX["south"], EPICENTRE[1] + radius * math.sin(angle) * 0.8))
+
+            damage = random.choices(DAMAGE_LEVELS, weights=ZONES[zone][2], k=1)[0]
+            infra = random.choices(INFRASTRUCTURE_TYPES, weights=INFRA_WEIGHTS, k=1)[0]
+
+            r = random.random()
+            if r < 0.6:
+                hours = random.uniform(0, 6)
+            elif r < 0.9:
+                hours = random.uniform(6, 48)
+            else:
+                hours = random.uniform(48, 120)
+            submitted = BASE_TIME + timedelta(hours=hours)
+
+            writer.writerow([
+                str(uuid.uuid4()),
+                f"SRID=4326;POINT({lng:.6f} {lat:.6f})",
+                h3.latlng_to_cell(lat, lng, 12),
+                h3.latlng_to_cell(lat, lng, 8),
+                "",  # building_id NULL
+                damage,
+                pg_array([infra]),
+                "",  # infrastructure_description NULL
+                pg_array(["Earthquake"]),
+                "t" if damage == "complete" else "f",
+                random.choice(ELECTRICITY),
+                random.choice(HEALTH),
+                pg_array(random.sample(NEEDS, k=random.randint(1, 3))),
+                str(uuid.uuid4()),  # every report its own chain
+                "t",  # is_latest
+                f"device-scale-{random.randint(1, 5000)}",
+                submitted.isoformat() + "+00",
+            ])
+            if (i + 1) % 100_000 == 0:
+                print(f"  {i + 1:,} rows...")
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="Generate scale-test report CSV")
+    parser.add_argument("--rows", type=int, default=500_000)
+    parser.add_argument("--out", default="scale_test_reports.csv")
+    args = parser.parse_args()
+    generate(args.out, args.rows)
+    print(f"Generated {args.out} ({args.rows:,} rows)")

--- a/db/scale_test_queries.sql
+++ b/db/scale_test_queries.sql
@@ -1,0 +1,42 @@
+-- Scale-test query set (#200). Run with \timing on against the test
+-- instance loaded by generate_scale_test.py. Record each timing for the
+-- Feasibility section. NEVER run the teardown against the demo DB.
+
+\timing on
+
+-- 1. Total count (dashboard header stat)
+SELECT count(*) FROM reports WHERE is_latest = true;
+
+-- 2. Damage-level filter (dashboard filter)
+SELECT count(*) FROM reports
+WHERE is_latest = true AND damage_level = 'complete';
+
+-- 3. H3 R8 cell lookup (area aggregation path)
+SELECT h3_r8, count(*), mode() WITHIN GROUP (ORDER BY damage_level)
+FROM reports
+WHERE is_latest = true
+GROUP BY h3_r8
+ORDER BY count(*) DESC
+LIMIT 20;
+
+-- 4. Bounding-box spatial query (map viewport fetch)
+SELECT count(*) FROM reports
+WHERE is_latest = true
+  AND location && ST_MakeEnvelope(36.14, 36.19, 36.18, 36.23, 4326);
+
+-- 5. Paginated viewport page (what GET /reports actually does)
+SELECT id, damage_level, ST_AsGeoJSON(location)
+FROM reports
+WHERE is_latest = true
+ORDER BY submitted_at DESC
+LIMIT 1000 OFFSET 0;
+
+-- 6. Export query at the current cap (exports.py, EXPORT_ROW_CAP = 10000)
+SELECT id, damage_level, infrastructure_type, ST_AsGeoJSON(location), submitted_at
+FROM reports
+WHERE is_latest = true
+ORDER BY submitted_at DESC
+LIMIT 10000;
+
+-- Teardown (test instance only!):
+-- DELETE FROM reports WHERE device_id LIKE 'device-scale-%';


### PR DESCRIPTION
Tooling for the empirical scale story in the submission's Feasibility section:

- `db/generate_scale_test.py` — N synthetic reports (default 500k) as CSV for `COPY` (INSERTs don't scale to this row count). Same severity-zone + crisis-wave shape as the demo seed so dashboards look plausible; distinct `device-scale-` prefix so teardown can never touch demo data. Smoke-tested at 2k rows.
- `db/scale_test_queries.sql` — timed query set covering the dashboard, spatial, H3-aggregation, and export paths.

**@foad decision needed:** this must run against a disposable instance, never the demo DB — can you spin a throwaway Supabase project (or local Postgres+PostGIS) for it? Happy for either of us to run it once that exists; the measured numbers slot straight into the proposal.

Closes #200