### PR TITLE
Coverage Endpoint

### DIFF
--- a/backend/src/handlers/api.py
+++ b/backend/src/handlers/api.py
@@ -20,7 +20,7 @@ from src.handlers.crisis_events import (
 )
 from src.handlers.exports import export_reports
 from src.handlers.photos import get_upload_url
-from src.handlers.reports import create_report, query_reports
+from src.handlers.reports import create_report, query_coverage, query_reports
 
 logger = Logger()
 tracer = Tracer()
@@ -71,6 +71,16 @@ def get_reports():
     params = app.current_event.query_string_parameters or {}
     try:
         return query_reports(params)
+    except ValidationError as e:
+        raise BadRequestError(_first_validation_message(e)) from e
+
+
+@app.get("/reports/coverage")
+@tracer.capture_method
+def get_reports_coverage():
+    params = app.current_event.query_string_parameters or {}
+    try:
+        return query_coverage(params)
     except ValidationError as e:
         raise BadRequestError(_first_validation_message(e)) from e
 

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -384,6 +384,34 @@ def query_reports(params: dict) -> dict:
     }
 
 
+def query_coverage(params: dict) -> dict:
+    """Public minimal-payload view for the community PWA's damage-fill layer
+
+    Returns (building_id, damage_level) per assessed building within the bbox
+    """
+    q = ReportsQueryParams(**params)
+    where, values = build_filter_clause(q)
+
+    conn = get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            SELECT building_id, damage_level
+            FROM reports
+            WHERE {where} AND building_id IS NOT NULL
+            LIMIT %s
+            """,
+            (*values, q.limit),
+        )
+        rows = cur.fetchall()
+
+    return {
+        "features": [
+            {"building_id": row[0], "damage_level": row[1]} for row in rows
+        ],
+    }
+
+
 def _find_version_chain(building_id: str | None, h3_r12: str) -> uuid.UUID:
     """Find existing version chain for this building, or create a new one."""
     conn = get_connection()

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -385,9 +385,10 @@ def query_reports(params: dict) -> dict:
 
 
 def query_coverage(params: dict) -> dict:
-    """Public minimal-payload view for the community PWA's damage-fill layer
+    """Public minimal-payload view for the community PWA
 
-    Returns (building_id, damage_level) per assessed building within the bbox
+    Returns a FeatureCollection with only (id, building_id, damage_level,
+    submitted_at) per row
     """
     q = ReportsQueryParams(**params)
     where, values = build_filter_clause(q)
@@ -396,19 +397,42 @@ def query_coverage(params: dict) -> dict:
     with conn.cursor() as cur:
         cur.execute(
             f"""
-            SELECT building_id, damage_level
+            SELECT
+                id, ST_X(location) as lng, ST_Y(location) as lat,
+                building_id, damage_level, submitted_at
             FROM reports
-            WHERE {where} AND building_id IS NOT NULL
-            LIMIT %s
+            WHERE {where}
+            ORDER BY submitted_at DESC
+            LIMIT %s OFFSET %s
             """,
-            (*values, q.limit),
+            (*values, q.limit, q.offset),
         )
         rows = cur.fetchall()
 
+        cur.execute(
+            f"SELECT COUNT(*) FROM reports WHERE {where}",
+            tuple(values),
+        )
+        total = cur.fetchone()[0]
+
+    features = [
+        {
+            "type": "Feature",
+            "geometry": {"type": "Point", "coordinates": [row[1], row[2]]},
+            "properties": {
+                "id": str(row[0]),
+                "building_id": row[3],
+                "damage_level": row[4],
+                "submitted_at": row[5].isoformat() if row[5] else None,
+            },
+        }
+        for row in rows
+    ]
+
     return {
-        "features": [
-            {"building_id": row[0], "damage_level": row[1]} for row in rows
-        ],
+        "type": "FeatureCollection",
+        "features": features,
+        "total": total,
     }
 
 

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -1,7 +1,13 @@
 import uuid
 from unittest.mock import MagicMock, patch
 
-from src.handlers.reports import ReportSubmission, _find_version_chain, create_report, query_reports
+from src.handlers.reports import (
+    ReportSubmission,
+    _find_version_chain,
+    create_report,
+    query_coverage,
+    query_reports,
+)
 
 
 def _valid_body(**overrides):
@@ -411,3 +417,148 @@ class TestFindVersionChain:
 
         result = _find_version_chain(None, "8a2a1072b59ffff")
         assert isinstance(result, uuid.UUID)
+
+
+class TestQueryCoverage:
+    @patch("src.handlers.reports.get_connection")
+    def test_returns_minimal_feature_collection(self, mock_get_conn):
+        from datetime import datetime, timezone
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        # SELECT id, lng, lat, building_id, damage_level, submitted_at
+        mock_cursor.fetchall.return_value = [
+            (
+                "report-id-1",
+                36.16,
+                36.2,
+                "u10k7d2q",
+                "partial",
+                datetime(2026, 4, 17, tzinfo=timezone.utc),
+            )
+        ]
+        mock_cursor.fetchone.return_value = (1,)
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = query_coverage({})
+
+        assert result["type"] == "FeatureCollection"
+        assert result["total"] == 1
+        assert len(result["features"]) == 1
+        feature = result["features"][0]
+        assert feature["geometry"]["coordinates"] == [36.16, 36.2]
+        props = feature["properties"]
+        assert props["id"] == "report-id-1"
+        assert props["building_id"] == "u10k7d2q"
+        assert props["damage_level"] == "partial"
+        assert props["submitted_at"] == "2026-04-17T00:00:00+00:00"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_response_excludes_sensitive_fields(self, mock_get_conn):
+        """Privacy regression — coverage must never leak detail fields."""
+        from datetime import datetime, timezone
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = [
+            (
+                "report-id-1", 36.16, 36.2, "u10k7d2q", "partial",
+                datetime(2026, 4, 17, tzinfo=timezone.utc),
+            )
+        ]
+        mock_cursor.fetchone.return_value = (1,)
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = query_coverage({})
+
+        props = result["features"][0]["properties"]
+        for forbidden in (
+            "photo_url",
+            "thumbnail_url",
+            "infrastructure_description",
+            "infrastructure_type",
+            "crisis_nature",
+            "ai_damage_level",
+            "ai_infrastructure_type",
+            "ai_confidence",
+            "follow_up_responses",
+            "electricity_status",
+            "health_status",
+            "pressing_needs",
+            "debris_present",
+        ):
+            assert forbidden not in props, (
+                f"coverage response leaked '{forbidden}'"
+            )
+
+        # SQL itself only selects the minimal columns.
+        sql = mock_cursor.execute.call_args_list[0][0][0]
+        for forbidden_col in (
+            "photo_url",
+            "infrastructure_description",
+            "follow_up_responses",
+            "ai_confidence",
+        ):
+            assert forbidden_col not in sql, (
+                f"coverage SELECT included '{forbidden_col}'"
+            )
+
+    @patch("src.handlers.reports.get_connection")
+    def test_empty_results(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.fetchone.return_value = (0,)
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        result = query_coverage(
+            {"west": "0", "south": "0", "east": "1", "north": "1"}
+        )
+
+        assert result["type"] == "FeatureCollection"
+        assert result["features"] == []
+        assert result["total"] == 0
+
+    @patch("src.handlers.reports.get_connection")
+    def test_filters_apply(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.fetchone.return_value = (0,)
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        query_coverage({"h3": "882da16601fffff", "damage_level": "complete"})
+
+        sql = mock_cursor.execute.call_args_list[0][0][0]
+        where = sql.split("WHERE")[-1].split("ORDER BY")[0]
+        assert "h3_r8 = %s" in where
+        assert "damage_level IN" in where
+
+    @patch("src.handlers.reports.get_connection")
+    def test_building_id_returns_all_versions(self, mock_get_conn):
+        mock_conn = MagicMock()
+        mock_cursor = MagicMock()
+        mock_cursor.fetchall.return_value = []
+        mock_cursor.fetchone.return_value = (0,)
+        mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+        mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+        mock_get_conn.return_value = mock_conn
+
+        query_coverage({"building_id": "u10k7d2q"})
+
+        sql = mock_cursor.execute.call_args_list[0][0][0]
+        main_where = sql.split("WHERE")[-1].split("ORDER BY")[0]
+        assert "is_latest = true" not in main_where
+        assert "building_id = %s" in main_where
+
+    def test_limit_over_1000_rejected(self):
+        import pytest
+        from pydantic import ValidationError
+        with pytest.raises(ValidationError):
+            query_coverage({"limit": "5000"})

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -13,9 +13,10 @@ Analyst / admin endpoints require a Cognito JWT in the `Authorization: Bearer <a
 | `POST /photos/upload` | public |
 | `POST /photos/classify` | public |
 | `GET /crisis-events/active` | public |
+| `GET /crisis-events` | public |
+| `GET /reports/coverage` | public |
 | `GET /reports` | **Bearer** |
 | `GET /reports/export` | **Bearer** |
-| `GET /crisis-events` | **Bearer** |
 | `POST /crisis-events` | **Bearer** |
 | `PUT /crisis-events/{event_id}` | **Bearer** |
 | `DELETE /crisis-events/{event_id}` | **Bearer** |
@@ -224,6 +225,10 @@ Return the active crisis event whose `region` polygon contains the given point. 
 ```
 
 `crisis_type` matches the English display strings stored in `reports.crisis_nature`.
+
+## GET /reports/coverage
+
+Public, minimal-payload view of reports for the community PWA — area count, existing-reports panel, and building damage-fill layer. Accepts the same query parameters as `GET /reports` (`west/south/east/north`, `h3`, `damage_level`, `infrastructure_type`, `crisis_nature`, `from`, `to`, `building_id`, `limit`, `offset`). Returns a GeoJSON `FeatureCollection` with only `id`, `building_id`, `damage_level`, `submitted_at` per feature, plus `total`. No photos, descriptions, AI fields, or follow-up responses — those live behind the authenticated `GET /reports`.
 
 ## GET /reports
 

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -268,7 +268,7 @@ export const Map = ({
       const b = map.getBounds();
       try {
         const result = await api(
-          `/reports?west=${b.getWest()}&south=${b.getSouth()}&east=${b.getEast()}&north=${b.getNorth()}&limit=500`,
+          `/reports/coverage?west=${b.getWest()}&south=${b.getSouth()}&east=${b.getEast()}&north=${b.getNorth()}&limit=500`,
         );
         const features: ReportFeature[] = result?.features ?? [];
         const seen = new Set<string>();

--- a/frontend/src/components/report-flow.tsx
+++ b/frontend/src/components/report-flow.tsx
@@ -72,7 +72,8 @@ export const ReportFlow = ({
     useState<AiClassification | null>(null);
   const classifiedKeyRef = useRef<string | null>(null);
   const [activeCrisisType, setActiveCrisisType] = useState<string | null>(null);
-  const [activeCrisisFollowUpQuestions, setActiveCrisisFollowUpQuestions] = useState<FollowUpQuestion[]>([]);
+  const [activeCrisisFollowUpQuestions, setActiveCrisisFollowUpQuestions] =
+    useState<FollowUpQuestion[]>([]);
   const [queuedReportId, setQueuedReportId] = useState<string | null>(null);
   const [activeCrisisName, setActiveCrisisName] = useState<string | null>(null);
   const crisisLookedUpRef = useRef(false);
@@ -173,7 +174,8 @@ export const ReportFlow = ({
           `/crisis-events/active?lat=${latitude}&lng=${longitude}`,
         );
         if (result?.crisis_type) setActiveCrisisType(result.crisis_type);
-        if (result?.follow_up_questions) setActiveCrisisFollowUpQuestions(result.follow_up_questions);
+        if (result?.follow_up_questions)
+          setActiveCrisisFollowUpQuestions(result.follow_up_questions);
         if (result?.name) setActiveCrisisName(result.name);
       } catch {
         // No active crisis at this location, or network error — silent drop.
@@ -188,7 +190,7 @@ export const ReportFlow = ({
     (async () => {
       try {
         const result = await api(
-          `/reports?building_id=${encodeURIComponent(buildingId)}`,
+          `/reports/coverage?building_id=${encodeURIComponent(buildingId)}`,
         );
         if (!cancelled) setExistingReports(result?.features ?? []);
       } catch {
@@ -208,7 +210,8 @@ export const ReportFlow = ({
 
   const handleAdvanceToSurvey = () => {
     const reportLat = selectedBuilding?.center[1] ?? manualPin?.[1] ?? latitude;
-    const reportLng = selectedBuilding?.center[0] ?? manualPin?.[0] ?? longitude;
+    const reportLng =
+      selectedBuilding?.center[0] ?? manualPin?.[0] ?? longitude;
     const seeded: PreSeeded = {};
     setSurvey((prev) => {
       let next = prev;
@@ -245,34 +248,41 @@ export const ReportFlow = ({
 
   const handleSubmit = async () => {
     const reportLat = selectedBuilding?.center[1] ?? manualPin?.[1] ?? latitude;
-    const reportLng = selectedBuilding?.center[0] ?? manualPin?.[0] ?? longitude;
+    const reportLng =
+      selectedBuilding?.center[0] ?? manualPin?.[0] ?? longitude;
     if (!damageLevel || reportLat == null || reportLng == null) return;
 
     setStep("submitting");
     setSubmitError(null);
 
     try {
-      const queued = await reportQueue.add({
-        id: crypto.randomUUID(),
-        photo: photo?.blob ? await photo.blob.arrayBuffer() : null,
-        photoContentType: photo?.blob?.type ?? null,
-        photoKey: photo?.photoKey ?? null,
-        latitude: reportLat,
-        longitude: reportLng,
-        buildingId: selectedBuilding?.buildingId ?? null,
-        damageLevel,
-        aiDamageLevel: aiClassification?.damageLevel ?? null,
-        aiInfrastructureType: aiClassification
-          ? aiClassification.infrastructureType
-              .map(
-                (key) => INFRASTRUCTURE_TYPES.find((t) => t.key === key)?.value,
-              )
-              .filter((v): v is string => Boolean(v))
-          : null,
-        aiConfidence: aiClassification?.damageConfidence ?? null,
-        surveyData: { ...survey },
-        createdAt: new Date().toISOString(),
-      }, activeCrisisFollowUpQuestions.length > 0 ? "awaiting-follow-up" : "pending");
+      const queued = await reportQueue.add(
+        {
+          id: crypto.randomUUID(),
+          photo: photo?.blob ? await photo.blob.arrayBuffer() : null,
+          photoContentType: photo?.blob?.type ?? null,
+          photoKey: photo?.photoKey ?? null,
+          latitude: reportLat,
+          longitude: reportLng,
+          buildingId: selectedBuilding?.buildingId ?? null,
+          damageLevel,
+          aiDamageLevel: aiClassification?.damageLevel ?? null,
+          aiInfrastructureType: aiClassification
+            ? aiClassification.infrastructureType
+                .map(
+                  (key) =>
+                    INFRASTRUCTURE_TYPES.find((t) => t.key === key)?.value,
+                )
+                .filter((v): v is string => Boolean(v))
+            : null,
+          aiConfidence: aiClassification?.damageConfidence ?? null,
+          surveyData: { ...survey },
+          createdAt: new Date().toISOString(),
+        },
+        activeCrisisFollowUpQuestions.length > 0
+          ? "awaiting-follow-up"
+          : "pending",
+      );
 
       saveSurveyPrefs(reportLat, reportLng, survey);
       setQueuedReportId(queued.id);
@@ -290,7 +300,9 @@ export const ReportFlow = ({
     }
   };
 
-  const handleFollowUpComplete = async (responses: Record<string, string> | null) => {
+  const handleFollowUpComplete = async (
+    responses: Record<string, string> | null,
+  ) => {
     if (queuedReportId) {
       if (responses && Object.keys(responses).length > 0) {
         await reportQueue.updateFollowUpResponses(queuedReportId, responses);
@@ -329,7 +341,10 @@ export const ReportFlow = ({
             onManualPin={handleManualPin}
           />
           <div className={styles.locationOverlay}>
-            <BuildingSelection building={selectedBuilding} manualPin={manualPin} />
+            <BuildingSelection
+              building={selectedBuilding}
+              manualPin={manualPin}
+            />
             <ExistingReports reports={existingReports} />
           </div>
         </div>

--- a/frontend/src/components/submission-confirmation.tsx
+++ b/frontend/src/components/submission-confirmation.tsx
@@ -1,5 +1,12 @@
 import { useEffect, useState } from "react";
-import { CircleCheck, CloudOff, Copy, Check, Shield, Share2 } from "lucide-react";
+import {
+  CircleCheck,
+  CloudOff,
+  Copy,
+  Check,
+  Shield,
+  Share2,
+} from "lucide-react";
 import { latLngToCell } from "h3-js";
 import { OpenLocationCode } from "open-location-code";
 import { useTranslation } from "react-i18next";
@@ -34,7 +41,9 @@ export const SubmissionConfirmation = ({
   const { t } = useTranslation();
   const [responses, setResponses] = useState<Record<string, string>>({});
   const [otherValues, setOtherValues] = useState<Record<string, string>>({});
-  const [otherSelected, setOtherSelected] = useState<Record<string, boolean>>({});
+  const [otherSelected, setOtherSelected] = useState<Record<string, boolean>>(
+    {},
+  );
   const [areaCount, setAreaCount] = useState<number | null>(null);
   const [copied, setCopied] = useState(false);
 
@@ -64,7 +73,7 @@ export const SubmissionConfirmation = ({
     (async () => {
       try {
         const h3Cell = latLngToCell(reportLat, reportLng, 8);
-        const result = await api(`/reports?h3=${h3Cell}&limit=1`);
+        const result = await api(`/reports/coverage?h3=${h3Cell}&limit=1`);
         if (!cancelled && typeof result?.total === "number") {
           setAreaCount(result.total);
         }
@@ -88,7 +97,10 @@ export const SubmissionConfirmation = ({
   const selectOther = (questionId: string) => {
     setOtherSelected((prev) => ({ ...prev, [questionId]: true }));
     const currentText = otherValues[questionId] ?? "";
-    setResponses((prev) => ({ ...prev, [questionId]: `Other: ${currentText}` }));
+    setResponses((prev) => ({
+      ...prev,
+      [questionId]: `Other: ${currentText}`,
+    }));
   };
 
   const setOther = (questionId: string, value: string) => {
@@ -98,7 +110,10 @@ export const SubmissionConfirmation = ({
 
   const handleComplete = () => {
     const hasEmptyOther = followUpQuestions.some(
-      (q) => q.allow_other && (otherSelected[q.id] ?? false) && !otherValues[q.id]?.trim(),
+      (q) =>
+        q.allow_other &&
+        (otherSelected[q.id] ?? false) &&
+        !otherValues[q.id]?.trim(),
     );
     if (hasEmptyOther) return;
     const finalResponses = Object.keys(responses).length > 0 ? responses : null;
@@ -193,7 +208,9 @@ export const SubmissionConfirmation = ({
       {hasQuestions && (
         <div className={styles.followUp}>
           <p className={styles.followUpHeading}>
-            {t("confirmation.followUpHeading", { count: followUpQuestions.length })}
+            {t("confirmation.followUpHeading", {
+              count: followUpQuestions.length,
+            })}
           </p>
           {followUpQuestions.map((q) => {
             const isOtherActive = otherSelected[q.id] ?? false;

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -13,6 +13,7 @@ const LoginPage = ({ mode }: LoginPageProps) => {
 
   useEffect(() => {
     auth.clearStaleState();
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
   useEffect(() => {
@@ -21,6 +22,7 @@ const LoginPage = ({ mode }: LoginPageProps) => {
     } else if (mode === "signout" && !auth.isAuthenticated) {
       navigate("/login", { replace: true });
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [mode, auth.isAuthenticated]);
 
   const email = (auth.user?.profile?.email as string | undefined) ?? null;

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -97,6 +97,18 @@ resource "aws_apigatewayv2_route" "get_crisis_events_active" {
   target    = "integrations/${aws_apigatewayv2_integration.api.id}"
 }
 
+resource "aws_apigatewayv2_route" "get_crisis_events" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /crisis-events"
+  target    = "integrations/${aws_apigatewayv2_integration.api.id}"
+}
+
+resource "aws_apigatewayv2_route" "get_reports_coverage" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /reports/coverage"
+  target    = "integrations/${aws_apigatewayv2_integration.api.id}"
+}
+
 # Protected routes — analyst dashboard reads + admin crisis CRUD.
 
 resource "aws_apigatewayv2_route" "get_reports" {
@@ -110,14 +122,6 @@ resource "aws_apigatewayv2_route" "get_reports" {
 resource "aws_apigatewayv2_route" "get_reports_export" {
   api_id             = aws_apigatewayv2_api.api.id
   route_key          = "GET /reports/export"
-  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
-  authorization_type = "JWT"
-  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
-}
-
-resource "aws_apigatewayv2_route" "get_crisis_events" {
-  api_id             = aws_apigatewayv2_api.api.id
-  route_key          = "GET /crisis-events"
   target             = "integrations/${aws_apigatewayv2_integration.api.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id


### PR DESCRIPTION
 - Add new coverage endpoint so public-facing PWA doesn't pull full report details
 - Open GET crisis-events up to the public since it doesn't contain anything sensitive and frontend needs it for pre-fill
 - More prettier linting