### PR TITLE
[#156] PII Filter on free text field

### DIFF
--- a/backend/src/handlers/pii_filter.py
+++ b/backend/src/handlers/pii_filter.py
@@ -1,0 +1,152 @@
+import os
+
+import boto3
+from aws_lambda_powertools import Logger
+from botocore.exceptions import ClientError
+
+logger = Logger()
+bedrock = boto3.client("bedrock-runtime")
+
+DEFAULT_MODEL_ID = "anthropic.claude-haiku-4-5-20251001-v1:0"
+
+PII_ENTITY_TYPES = [
+    "PERSON_NAME",
+    "PHONE_NUMBER",
+    "EMAIL_ADDRESS",
+    "ID_NUMBER",
+    "FINANCIAL_INFO",
+    "OTHER_PII",
+]
+
+SYSTEM_PROMPT = """You identify personally identifiable information (PII) in user-submitted free
+text from a community crisis-reporting app. The text may be in any language.
+
+Call the report_pii_redactions tool with each PII span you find — copying the
+EXACT substring as it appears in the input (character-for-character, including
+spaces and punctuation) plus the entity type. Do not paraphrase, translate, or
+adjust the substring. The redaction step is a literal string replacement.
+
+PII to identify:
+- PERSON_NAME: full or first+last names of specific individuals
+- PHONE_NUMBER: telephone numbers in any format
+- EMAIL_ADDRESS: email addresses
+- ID_NUMBER: national ID, passport, driver licence numbers
+- FINANCIAL_INFO: bank account numbers, credit cards, IBANs
+- OTHER_PII: clear PII not covered above (e.g. social media handles)
+
+Do NOT flag:
+- Addresses or postal addresses — the location of damaged infrastructure is
+  the intended content of this field
+- Building names ("Al-Noor School", "City Hospital", "Hatay Bus Terminal")
+- Landmark references ("near the central market", "behind the school")
+- Generic role descriptions ("the imam", "the headmaster", "the caretaker")
+- Vehicle make/model
+- Damage descriptions
+- Generic place names (cities, neighbourhoods)
+
+If no PII is present, call the tool with an empty redactions array.
+Always call the tool — do not respond in plain text."""
+
+PII_TOOL = {
+    "toolSpec": {
+        "name": "report_pii_redactions",
+        "description": "Report the exact substrings to redact and their entity types.",
+        "inputSchema": {
+            "json": {
+                "type": "object",
+                "properties": {
+                    "redactions": {
+                        "type": "array",
+                        "items": {
+                            "type": "object",
+                            "properties": {
+                                "text": {
+                                    "type": "string",
+                                    "description": "The exact substring from the input, copied verbatim.",
+                                },
+                                "entity_type": {"type": "string", "enum": PII_ENTITY_TYPES},
+                            },
+                            "required": ["text", "entity_type"],
+                        },
+                    },
+                },
+                "required": ["redactions"],
+            },
+        },
+    }
+}
+
+
+def redact_pii(text: str) -> tuple[str, list[str]]:
+    """Return (redacted_text, entity_types_found).
+
+    Falls back to (text, []) on Bedrock failure — PII filter unavailability
+    must not block legitimate submissions.
+    """
+    if not text or not text.strip():
+        return text, []
+
+    redactions = _detect_pii_redactions(text)
+    if not redactions:
+        return text, []
+
+    return _apply_redactions(text, redactions), [r["entity_type"] for r in redactions]
+
+
+def _detect_pii_redactions(text: str) -> list[dict]:
+    model_id = os.environ.get("BEDROCK_MODEL_ID", DEFAULT_MODEL_ID)
+    try:
+        response = bedrock.converse(
+            modelId=model_id,
+            system=[{"text": SYSTEM_PROMPT}],
+            messages=[{"role": "user", "content": [{"text": text}]}],
+            toolConfig={
+                "tools": [PII_TOOL],
+                "toolChoice": {"tool": {"name": "report_pii_redactions"}},
+            },
+        )
+    except ClientError:
+        logger.exception("pii detection bedrock call failed")
+        return []
+    except Exception:
+        logger.exception("pii detection unexpected error")
+        return []
+
+    content = response.get("output", {}).get("message", {}).get("content", [])
+    tool_use = next((c["toolUse"] for c in content if "toolUse" in c), None)
+    if not tool_use or tool_use.get("name") != "report_pii_redactions":
+        logger.warning("pii detection model did not call tool")
+        return []
+
+    raw = tool_use.get("input", {}).get("redactions", [])
+    return _validate_redactions(raw, text)
+
+
+def _validate_redactions(redactions: list, text: str) -> list[dict]:
+    valid = []
+    for r in redactions:
+        if not isinstance(r, dict):
+            continue
+        pii_text = r.get("text")
+        entity = r.get("entity_type")
+        if not isinstance(pii_text, str) or not pii_text:
+            continue
+        if entity not in PII_ENTITY_TYPES:
+            continue
+        # Drop hallucinated spans — the model occasionally returns text that
+        # isn't actually in the input. str.replace would no-op anyway, but
+        # filtering here keeps the returned entity_types accurate.
+        if pii_text not in text:
+            continue
+        valid.append({"text": pii_text, "entity_type": entity})
+    return valid
+
+
+def _apply_redactions(text: str, redactions: list[dict]) -> str:
+    # Apply longest substrings first so a shorter PII span that's a substring
+    # of a longer one (e.g. "John" inside "John Smith") doesn't over-redact.
+    sorted_redactions = sorted(redactions, key=lambda r: len(r["text"]), reverse=True)
+    result = text
+    for r in sorted_redactions:
+        result = result.replace(r["text"], f"[{r['entity_type']}]")
+    return result

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -8,6 +8,7 @@ import h3
 from aws_lambda_powertools import Logger
 from pydantic import BaseModel, ConfigDict, Field
 
+from src.handlers.pii_filter import redact_pii
 from src.utils.db import get_connection
 
 logger = Logger()
@@ -156,6 +157,19 @@ def create_report(body: dict) -> dict:
                     "status": "duplicate",
                     "message": "Report already submitted from offline queue",
                 }
+
+    # Redact PII from user-submitted free-text. Best-effort: a Bedrock failure
+    # falls through with the original text rather than blocking the submission.
+    for _field in ("infrastructure_description", "infrastructure_type_other", "pressing_needs_other"):
+        _raw = getattr(submission, _field)
+        if _raw:
+            _redacted, _entities = redact_pii(_raw)
+            if _entities:
+                setattr(submission, _field, _redacted)
+                logger.info(
+                    "pii_redacted",
+                    extra={"field": _field, "entity_types": _entities, "count": len(_entities)},
+                )
 
     # Compute H3 indexes
     h3_r12 = h3.latlng_to_cell(submission.latitude, submission.longitude, 12)

--- a/backend/tests/test_pii_filter.py
+++ b/backend/tests/test_pii_filter.py
@@ -1,0 +1,175 @@
+from unittest.mock import patch
+
+from botocore.exceptions import ClientError
+
+from src.handlers.pii_filter import (
+    _apply_redactions,
+    _validate_redactions,
+    redact_pii,
+)
+
+
+def _bedrock_response(redactions: list) -> dict:
+    return {
+        "output": {
+            "message": {
+                "role": "assistant",
+                "content": [
+                    {
+                        "toolUse": {
+                            "toolUseId": "tool-1",
+                            "name": "report_pii_redactions",
+                            "input": {"redactions": redactions},
+                        }
+                    }
+                ],
+            }
+        },
+        "stopReason": "tool_use",
+    }
+
+
+class TestApplyRedactions:
+    def test_single_redaction_replaced(self):
+        text = "Call John Smith at the school"
+        redactions = [{"text": "John Smith", "entity_type": "PERSON_NAME"}]
+        assert _apply_redactions(text, redactions) == "Call [PERSON_NAME] at the school"
+
+    def test_multiple_redactions(self):
+        text = "Contact John at 555-1234"
+        redactions = [
+            {"text": "John", "entity_type": "PERSON_NAME"},
+            {"text": "555-1234", "entity_type": "PHONE_NUMBER"},
+        ]
+        assert _apply_redactions(text, redactions) == "Contact [PERSON_NAME] at [PHONE_NUMBER]"
+
+    def test_longest_substring_first_prevents_overlap(self):
+        # If "John" is processed before "John Smith", we'd corrupt the full
+        # name. Longest-first sort prevents this.
+        text = "John Smith and John are both reported"
+        redactions = [
+            {"text": "John", "entity_type": "PERSON_NAME"},
+            {"text": "John Smith", "entity_type": "PERSON_NAME"},
+        ]
+        result = _apply_redactions(text, redactions)
+        assert result == "[PERSON_NAME] and [PERSON_NAME] are both reported"
+
+    def test_entire_text_redacted(self):
+        text = "john@example.com"
+        redactions = [{"text": "john@example.com", "entity_type": "EMAIL_ADDRESS"}]
+        assert _apply_redactions(text, redactions) == "[EMAIL_ADDRESS]"
+
+    def test_no_redactions_returns_original(self):
+        assert _apply_redactions("nothing here", []) == "nothing here"
+
+
+class TestValidateRedactions:
+    def test_valid_redactions_pass_through(self):
+        text = "John Smith called"
+        redactions = [{"text": "John Smith", "entity_type": "PERSON_NAME"}]
+        assert _validate_redactions(redactions, text) == redactions
+
+    def test_drops_text_not_in_input(self):
+        # Defensive against model hallucination: if the returned substring
+        # isn't actually in the input, drop it.
+        text = "Some report text"
+        redactions = [{"text": "Made Up Name", "entity_type": "PERSON_NAME"}]
+        assert _validate_redactions(redactions, text) == []
+
+    def test_drops_empty_text(self):
+        redactions = [{"text": "", "entity_type": "PERSON_NAME"}]
+        assert _validate_redactions(redactions, "anything") == []
+
+    def test_drops_unknown_entity_type(self):
+        text = "John Smith"
+        redactions = [{"text": "John Smith", "entity_type": "MADE_UP_TYPE"}]
+        assert _validate_redactions(redactions, text) == []
+
+    def test_drops_missing_fields(self):
+        text = "anything"
+        assert _validate_redactions([{"text": "anything"}], text) == []
+        assert _validate_redactions([{"entity_type": "PERSON_NAME"}], text) == []
+
+    def test_drops_non_dict(self):
+        assert _validate_redactions(["not-a-dict", None], "anything") == []
+
+    def test_mixed_valid_and_invalid(self):
+        text = "John called 555-1234"
+        redactions = [
+            {"text": "John", "entity_type": "PERSON_NAME"},  # valid
+            {"text": "Fake Name", "entity_type": "PERSON_NAME"},  # not in text
+            {"text": "555-1234", "entity_type": "PHONE_NUMBER"},  # valid
+        ]
+        assert len(_validate_redactions(redactions, text)) == 2
+
+
+class TestRedactPii:
+    def test_empty_text_returns_empty(self):
+        assert redact_pii("") == ("", [])
+        assert redact_pii("   ") == ("   ", [])
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_no_pii_returns_original(self, mock_bedrock):
+        mock_bedrock.converse.return_value = _bedrock_response([])
+        text = "South wall collapsed, roof intact"
+        assert redact_pii(text) == (text, [])
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_detects_and_redacts_pii(self, mock_bedrock):
+        text = "Owner is John Smith"
+        mock_bedrock.converse.return_value = _bedrock_response([
+            {"text": "John Smith", "entity_type": "PERSON_NAME"},
+        ])
+        redacted, entities = redact_pii(text)
+        assert redacted == "Owner is [PERSON_NAME]"
+        assert entities == ["PERSON_NAME"]
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_bedrock_error_falls_through(self, mock_bedrock):
+        mock_bedrock.converse.side_effect = ClientError(
+            {"Error": {"Code": "ThrottlingException"}}, "Converse"
+        )
+        text = "Some description"
+        # Failure must not block submission — return original text untouched.
+        assert redact_pii(text) == (text, [])
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_model_did_not_call_tool_falls_through(self, mock_bedrock):
+        mock_bedrock.converse.return_value = {
+            "output": {"message": {"role": "assistant", "content": [{"text": "ok"}]}},
+            "stopReason": "end_turn",
+        }
+        text = "Some description"
+        assert redact_pii(text) == (text, [])
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_hallucinated_redactions_dropped(self, mock_bedrock):
+        text = "Short text with no PII"
+        mock_bedrock.converse.return_value = _bedrock_response([
+            {"text": "Some Name That Is Not Here", "entity_type": "PERSON_NAME"},
+        ])
+        # Hallucinated span → not in text → dropped → original returned
+        assert redact_pii(text) == (text, [])
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_arabic_text(self, mock_bedrock):
+        text = "الاتصال بـ أحمد علي"
+        mock_bedrock.converse.return_value = _bedrock_response([
+            {"text": "أحمد علي", "entity_type": "PERSON_NAME"},
+        ])
+        redacted, entities = redact_pii(text)
+        assert redacted == "الاتصال بـ [PERSON_NAME]"
+        assert entities == ["PERSON_NAME"]
+
+    @patch("src.handlers.pii_filter.bedrock")
+    def test_japanese_text(self, mock_bedrock):
+        # Character-offset-based redaction was failing on multibyte scripts;
+        # string-replace must handle Japanese without corruption.
+        text = "管理人の田中健太、電話番号 090-1234-5678。"
+        mock_bedrock.converse.return_value = _bedrock_response([
+            {"text": "田中健太", "entity_type": "PERSON_NAME"},
+            {"text": "090-1234-5678", "entity_type": "PHONE_NUMBER"},
+        ])
+        redacted, entities = redact_pii(text)
+        assert redacted == "管理人の[PERSON_NAME]、電話番号 [PHONE_NUMBER]。"
+        assert sorted(entities) == ["PERSON_NAME", "PHONE_NUMBER"]


### PR DESCRIPTION
closes #156 

 - Ticket originally planned to use AWS Comprehend but it doesn't support 3 of the 6 UN languages
 - Instead, went with a tool call to Bedrock to replace PII content

Tested with:

## 1. Control — English, no PII

> Hatay Bus Terminal — concrete pillars cracked at the western entrance, partial roof collapse near the ticket office. Located two blocks east of the river. Vehicle access blocked. PII-TEST-CASE

**Expected:** stored verbatim. No redactions. Building name, landmark reference, and damage details are exactly the field's intended content.

---

## 2. Spanish — person name + phone

> Centro de salud Las Palmas — techo derrumbado en el ala oeste. Para más información contactar al director Juan García al +34 612 345 678. Edificio evacuado. PII-TEST-CASE

**Expected redactions:** `Juan García` → `[PERSON_NAME]`, `+34 612 345 678` → `[PHONE_NUMBER]`
**Must NOT touch:** "Centro de salud Las Palmas", "el director" (generic role), damage description.

---

## 3. Japanese — person name + phone

> 中央市場の隣の小学校 — 西側の壁が崩れ、屋根は無事。連絡先は管理人の田中健太、電話番号 090-1234-5678。建物は使用禁止。PII-TEST-CASE

**Expected redactions:** `田中健太` → `[PERSON_NAME]`, `090-1234-5678` → `[PHONE_NUMBER]`
**Must NOT touch:** "中央市場の隣の小学校" (landmark school reference), "管理人" (generic role: caretaker), damage description. Also exercises a non-UN language Claude handles natively.

---

## 4. Arabic (RTL) — person name + phone

> مدرسة النور الابتدائية — انهار الجدار الجنوبي، السقف سليم، الطابق الأرضي غارق بالمياه. للتواصل: المدير محمد الأحمد، هاتف ٠٥٠١٢٣٤٥٦٧. الموقع آمن للزيارة. PII-TEST-CASE

**Expected redactions:**

- Person name (Mohammed Al-Ahmad / `محمد الأحمد`) → `[PERSON_NAME]`
- Phone number in Eastern Arabic digits (`٠٥٠١٢٣٤٥٦٧`, i.e. 0501234567) → `[PHONE_NUMBER]`

**Must NOT touch:**

- School name (`مدرسة النور الابتدائية` / "Al-Noor Primary School")
- Generic role (`المدير` / "the director")
- Damage description (`انهار الجدار الجنوبي...` etc.)

Exercises right-to-left layout and Arabic-Indic numerals — the phone is in Eastern Arabic digits, not Western 0-9.

---

## Results:

All four passing

> Hatay Bus Terminal — concrete pillars cracked at the western entrance, partial roof collapse near the ticket office. Located two blocks east of the river. Vehicle access blocked. PII-TEST-CASE

> Centro de salud Las Palmas — techo derrumbado en el ala oeste. Para más información contactar al director [PERSON_NAME] al [PHONE_NUMBER]. Edificio evacuado. PII-TEST-CASE

> 中央市場の隣の小学校 — 西側の壁が崩れ、屋根は無事。連絡先は管理人の[PERSON_NAME]、電話番号 [PHONE_NUMBER]。建物は使用禁止。PII-TEST-CASE

> مدرسة النور الابتدائية — انهار الجدار الجنوبي، السقف سليم، الطابق الأرضي غارق بالمياه. للتواصل: المدير [PERSON_NAME]، هاتف [PHONE_NUMBER]. الموقع آمن للزيارة. PII-TEST-CASE