### PR TITLE
feat: analyst damage reclassification and report flagging (#169, #170)

### DIFF
--- a/backend/src/handlers/api.py
+++ b/backend/src/handlers/api.py
@@ -20,7 +20,7 @@ from src.handlers.crisis_events import (
 )
 from src.handlers.exports import export_reports
 from src.handlers.photos import get_upload_url
-from src.handlers.reports import create_report, query_coverage, query_reports
+from src.handlers.reports import create_report, query_coverage, query_reports, review_report
 
 logger = Logger()
 tracer = Tracer()
@@ -164,6 +164,18 @@ def post_report():
         return create_report(body)
     except ValidationError as e:
         raise BadRequestError(_first_validation_message(e)) from e
+
+
+@app.patch("/reports/<report_id>/review")
+@tracer.capture_method
+def patch_report_review(report_id: str):
+    body = app.current_event.json_body if app.current_event.body else {}
+    try:
+        return review_report(report_id, body)
+    except ValueError as e:
+        if str(e).startswith("No report with id"):
+            raise NotFoundError(str(e)) from e
+        raise BadRequestError(str(e)) from e
 
 
 @app.exception_handler(Exception)

--- a/backend/src/handlers/exports.py
+++ b/backend/src/handlers/exports.py
@@ -64,6 +64,9 @@ def export_reports(params: dict) -> tuple[str, str, str]:
     """Return (body, content_type, filename) for the requested export."""
     q = ExportParams(**params)
     where, values = build_filter_clause(q)
+    # Flagged reports (#170) stay visible on the dashboard but are excluded
+    # from exports — they must not feed downstream aid analysis.
+    where += " AND flag_status IS NULL"
 
     conn = get_connection()
     with conn.cursor() as cur:
@@ -71,7 +74,7 @@ def export_reports(params: dict) -> tuple[str, str, str]:
             f"""
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
-                building_id, damage_level,
+                building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
                 ai_damage_level, ai_confidence,
                 photo_url, thumbnail_url,
                 infrastructure_type, infrastructure_description,

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -422,7 +422,8 @@ def query_coverage(params: dict) -> dict:
             f"""
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
-                building_id, damage_level, submitted_at
+                building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
+                submitted_at
             FROM reports
             WHERE {where}
             ORDER BY submitted_at DESC
@@ -497,8 +498,11 @@ def review_report(report_id: str, body: dict) -> dict:
 
     if "flag_reason" in body:
         reason = body["flag_reason"]
-        if reason is not None and len(reason) > 500:
-            raise ValueError("flag_reason must be 500 characters or fewer")
+        if reason is not None:
+            if len(reason) > 500:
+                raise ValueError("flag_reason must be 500 characters or fewer")
+            if "flag_status" not in body:
+                raise ValueError("flag_reason requires flag_status to be set in the same request")
         updates.append("flag_reason = %s")
         values.append(reason)
 
@@ -520,6 +524,7 @@ def review_report(report_id: str, body: dict) -> dict:
             (*values, report_id),
         )
         row = cur.fetchone()
+    conn.commit()
     if row is None:
         raise ValueError(f"No report with id {report_id}")
 

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -286,7 +286,11 @@ def build_filter_clause(q: "ReportsQueryParams | object") -> tuple[str, list]:
     if q.damage_level:
         levels = q.damage_level.split(",")
         placeholders = ",".join(["%s"] * len(levels))
-        conditions.append(f"damage_level IN ({placeholders})")
+        # Filter on the effective level: an analyst override (#169) supersedes
+        # the community classification everywhere downstream.
+        conditions.append(
+            f"COALESCE(analyst_damage_level, damage_level) IN ({placeholders})"
+        )
         values.extend(levels)
 
     if q.infrastructure_type:
@@ -331,7 +335,7 @@ def query_reports(params: dict) -> dict:
             f"""
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
-                building_id, damage_level,
+                building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
                 ai_damage_level, ai_infrastructure_type, ai_confidence,
                 photo_url, thumbnail_url,
                 infrastructure_type, infrastructure_description,
@@ -341,7 +345,8 @@ def query_reports(params: dict) -> dict:
                 duplicate_status, related_report_id,
                 (SELECT COUNT(*) FROM reports r2
                  WHERE r2.version_chain_id = reports.version_chain_id) as version_count,
-                follow_up_responses
+                follow_up_responses,
+                damage_level, analyst_damage_level, flag_status, flag_reason
             FROM reports
             WHERE {where}
             ORDER BY submitted_at DESC
@@ -388,6 +393,10 @@ def query_reports(params: dict) -> dict:
                 "related_report_id": str(row[21]) if row[21] else None,
                 "version_count": row[22],
                 "follow_up_responses": row[23],
+                "community_damage_level": row[24],
+                "analyst_damage_level": row[25],
+                "flag_status": row[26],
+                "flag_reason": row[27],
             },
         })
 
@@ -447,6 +456,80 @@ def query_coverage(params: dict) -> dict:
         "type": "FeatureCollection",
         "features": features,
         "total": total,
+    }
+
+
+REVIEW_DAMAGE_LEVELS = {"minimal", "partial", "complete"}
+REVIEW_FLAG_STATUSES = {"suspect", "invalid"}
+
+
+def review_report(report_id: str, body: dict) -> dict:
+    """Analyst review actions (#169, #170): set or clear a damage-level
+    override and/or a flag. The community's original classification is never
+    overwritten — overrides live in analyst_damage_level and all queries read
+    the effective level via COALESCE.
+
+    Accepts any of: analyst_damage_level (level or null to clear),
+    flag_status ('suspect' | 'invalid' | null to clear), flag_reason (text).
+    """
+    updates = []
+    values: list = []
+
+    if "analyst_damage_level" in body:
+        level = body["analyst_damage_level"]
+        if level is not None and level not in REVIEW_DAMAGE_LEVELS:
+            raise ValueError(
+                f"analyst_damage_level must be one of {sorted(REVIEW_DAMAGE_LEVELS)} or null"
+            )
+        updates.append("analyst_damage_level = %s")
+        values.append(level)
+
+    if "flag_status" in body:
+        status = body["flag_status"]
+        if status is not None and status not in REVIEW_FLAG_STATUSES:
+            raise ValueError(
+                f"flag_status must be one of {sorted(REVIEW_FLAG_STATUSES)} or null"
+            )
+        updates.append("flag_status = %s")
+        values.append(status)
+        if status is None:
+            updates.append("flag_reason = NULL")
+
+    if "flag_reason" in body:
+        reason = body["flag_reason"]
+        if reason is not None and len(reason) > 500:
+            raise ValueError("flag_reason must be 500 characters or fewer")
+        updates.append("flag_reason = %s")
+        values.append(reason)
+
+    if not updates:
+        raise ValueError(
+            "Provide at least one of: analyst_damage_level, flag_status, flag_reason"
+        )
+
+    conn = get_connection()
+    with conn.cursor() as cur:
+        cur.execute(
+            f"""
+            UPDATE reports
+            SET {", ".join(updates)}, updated_at = now()
+            WHERE id = %s
+            RETURNING id, COALESCE(analyst_damage_level, damage_level),
+                      damage_level, analyst_damage_level, flag_status, flag_reason
+            """,
+            (*values, report_id),
+        )
+        row = cur.fetchone()
+    if row is None:
+        raise ValueError(f"No report with id {report_id}")
+
+    return {
+        "id": str(row[0]),
+        "damage_level": row[1],
+        "community_damage_level": row[2],
+        "analyst_damage_level": row[3],
+        "flag_status": row[4],
+        "flag_reason": row[5],
     }
 
 

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -176,6 +176,7 @@ class TestQueryReports:
                 None, None,  # duplicate_status, related_report_id
                 1,
                 None,  # follow_up_responses
+                "partial", None, None, None,  # community_damage_level, analyst_damage_level, flag_status, flag_reason
             )
         ]
         mock_cursor.fetchone.return_value = (1,)

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -7,6 +7,7 @@ from src.handlers.reports import (
     create_report,
     query_coverage,
     query_reports,
+    review_report,
 )
 
 
@@ -563,3 +564,104 @@ class TestQueryCoverage:
         from pydantic import ValidationError
         with pytest.raises(ValidationError):
             query_coverage({"limit": "5000"})
+
+
+def _make_review_conn(fetchone_result):
+    mock_conn = MagicMock()
+    mock_cursor = MagicMock()
+    mock_cursor.fetchone.return_value = fetchone_result
+    mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
+    mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
+    return mock_conn, mock_cursor
+
+
+class TestReviewReport:
+    @patch("src.handlers.reports.get_connection")
+    def test_set_analyst_damage_level(self, mock_get_conn):
+        row = ("report-1", "complete", "partial", "complete", None, None)
+        mock_conn, _ = _make_review_conn(row)
+        mock_get_conn.return_value = mock_conn
+
+        result = review_report("report-1", {"analyst_damage_level": "complete"})
+
+        assert result["damage_level"] == "complete"
+        assert result["community_damage_level"] == "partial"
+        assert result["analyst_damage_level"] == "complete"
+        assert result["flag_status"] is None
+
+    @patch("src.handlers.reports.get_connection")
+    def test_clear_analyst_damage_level(self, mock_get_conn):
+        row = ("report-1", "partial", "partial", None, None, None)
+        mock_conn, mock_cursor = _make_review_conn(row)
+        mock_get_conn.return_value = mock_conn
+
+        result = review_report("report-1", {"analyst_damage_level": None})
+
+        assert result["analyst_damage_level"] is None
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "analyst_damage_level = %s" in sql
+
+    @patch("src.handlers.reports.get_connection")
+    def test_set_flag_status(self, mock_get_conn):
+        row = ("report-1", "partial", "partial", None, "suspect", None)
+        mock_conn, _ = _make_review_conn(row)
+        mock_get_conn.return_value = mock_conn
+
+        result = review_report("report-1", {"flag_status": "suspect"})
+
+        assert result["flag_status"] == "suspect"
+
+    @patch("src.handlers.reports.get_connection")
+    def test_clear_flag_status_also_clears_reason(self, mock_get_conn):
+        row = ("report-1", "partial", "partial", None, None, None)
+        mock_conn, mock_cursor = _make_review_conn(row)
+        mock_get_conn.return_value = mock_conn
+
+        review_report("report-1", {"flag_status": None})
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "flag_reason = NULL" in sql
+
+    @patch("src.handlers.reports.get_connection")
+    def test_commit_is_called(self, mock_get_conn):
+        row = ("report-1", "partial", "partial", None, None, None)
+        mock_conn, _ = _make_review_conn(row)
+        mock_get_conn.return_value = mock_conn
+
+        review_report("report-1", {"flag_status": "invalid"})
+
+        mock_conn.commit.assert_called_once()
+
+    @patch("src.handlers.reports.get_connection")
+    def test_report_not_found_raises(self, mock_get_conn):
+        import pytest
+        mock_conn, _ = _make_review_conn(None)
+        mock_get_conn.return_value = mock_conn
+
+        with pytest.raises(ValueError, match="No report with id"):
+            review_report("missing-id", {"flag_status": "suspect"})
+
+    def test_empty_body_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="Provide at least one of"):
+            review_report("report-1", {})
+
+    def test_invalid_damage_level_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="analyst_damage_level must be one of"):
+            review_report("report-1", {"analyst_damage_level": "destroyed"})
+
+    def test_invalid_flag_status_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="flag_status must be one of"):
+            review_report("report-1", {"flag_status": "maybe"})
+
+    def test_flag_reason_without_flag_status_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="flag_reason requires flag_status"):
+            review_report("report-1", {"flag_reason": "looks fake"})
+
+    def test_flag_reason_too_long_raises(self):
+        import pytest
+        with pytest.raises(ValueError, match="500 characters or fewer"):
+            review_report("report-1", {"flag_status": "suspect", "flag_reason": "x" * 501})

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -265,7 +265,7 @@ class TestQueryReports:
 
         sql = mock_cursor.execute.call_args_list[0][0][0]
         main_where = sql.split("WHERE")[-1].split("ORDER BY")[0]
-        assert "damage_level IN" in main_where
+        assert "COALESCE(analyst_damage_level, damage_level) IN" in main_where
         params = mock_cursor.execute.call_args_list[0][0][1]
         assert "partial" in params
         assert "complete" in params
@@ -361,7 +361,7 @@ class TestQueryReports:
 
         sql = mock_cursor.execute.call_args_list[0][0][0]
         main_where = sql.split("WHERE")[-1].split("ORDER BY")[0]
-        assert "damage_level IN" in main_where
+        assert "COALESCE(analyst_damage_level, damage_level) IN" in main_where
         assert "ANY(crisis_nature)" in main_where
         assert "submitted_at >=" in main_where
 
@@ -538,7 +538,7 @@ class TestQueryCoverage:
         sql = mock_cursor.execute.call_args_list[0][0][0]
         where = sql.split("WHERE")[-1].split("ORDER BY")[0]
         assert "h3_r8 = %s" in where
-        assert "damage_level IN" in where
+        assert "COALESCE(analyst_damage_level, damage_level) IN" in where
 
     @patch("src.handlers.reports.get_connection")
     def test_building_id_returns_all_versions(self, mock_get_conn):

--- a/db/010_analyst_review.sql
+++ b/db/010_analyst_review.sql
@@ -1,0 +1,10 @@
+-- Analyst trust tools: damage reclassification (#169) and report flagging (#170)
+-- The community's original damage_level is never overwritten — the override
+-- lives alongside it and queries read COALESCE(analyst_damage_level, damage_level).
+ALTER TABLE reports ADD COLUMN analyst_damage_level TEXT
+    CHECK (analyst_damage_level IN ('minimal', 'partial', 'complete'));
+ALTER TABLE reports ADD COLUMN flag_status TEXT
+    CHECK (flag_status IN ('suspect', 'invalid'));
+ALTER TABLE reports ADD COLUMN flag_reason TEXT;
+
+CREATE INDEX idx_reports_flag_status ON reports (flag_status) WHERE flag_status IS NOT NULL;

--- a/frontend/src/components/report-details-modal.module.css
+++ b/frontend/src/components/report-details-modal.module.css
@@ -114,3 +114,91 @@
   flex-direction: column;
   gap: 4px;
 }
+
+/* --- Analyst review (#169, #170) --- */
+.review {
+  border-top: 1px solid var(--undpds-color-gray-300);
+  padding-top: 12px;
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.reviewTitle {
+  font-weight: 700;
+  font-size: 0.6875rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--undpds-color-gray-700);
+}
+
+.flagBanner {
+  background: var(--undpds-color-red-200);
+  color: var(--undpds-color-black);
+  font-size: 0.8125rem;
+  padding: 6px 10px;
+}
+
+.reviewRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.reviewLabel {
+  font-size: 0.75rem;
+  color: var(--undpds-color-gray-600);
+  min-width: 90px;
+}
+
+.reviewButtons {
+  display: flex;
+  gap: 6px;
+}
+
+.reviewBtn {
+  padding: 4px 10px;
+  font-size: 0.75rem;
+  font-weight: 600;
+  background: var(--undpds-color-white);
+  color: var(--undpds-color-gray-700);
+  border: 1px solid var(--undpds-color-gray-300);
+  cursor: pointer;
+  text-transform: capitalize;
+}
+
+.reviewBtn:hover:not(:disabled) {
+  background: var(--undpds-color-gray-200);
+}
+
+.reviewBtn:disabled {
+  opacity: 0.5;
+  cursor: default;
+}
+
+.reviewBtnActive {
+  background: var(--undpds-color-blue-600, #0469a5);
+  border-color: var(--undpds-color-blue-600, #0469a5);
+  color: var(--undpds-color-white);
+}
+
+.reviewNote {
+  font-size: 0.75rem;
+  color: var(--undpds-color-gray-600);
+}
+
+.reviewLink {
+  background: none;
+  border: none;
+  padding: 0;
+  font-size: 0.75rem;
+  color: var(--undpds-color-blue-600, #0469a5);
+  text-decoration: underline;
+  cursor: pointer;
+}
+
+.reviewError {
+  font-size: 0.75rem;
+  color: var(--undpds-color-red);
+}

--- a/frontend/src/components/report-details-modal.module.css
+++ b/frontend/src/components/report-details-modal.module.css
@@ -169,7 +169,11 @@
 }
 
 .reviewBtn:hover:not(:disabled) {
-  background: var(--undpds-color-gray-200);
+  background: var(--undpds-color-gray-400);
+}
+
+.reviewBtn.reviewBtnActive:hover:not(:disabled) {
+  background: var(--undpds-color-blue-700);
 }
 
 .reviewBtn:disabled {

--- a/frontend/src/components/report-details-modal.tsx
+++ b/frontend/src/components/report-details-modal.tsx
@@ -138,7 +138,7 @@ export const ReportDetailsModal = ({
                     onClick={() =>
                       sendReview({
                         analyst_damage_level:
-                          level === p.community_damage_level ? null : level,
+                          level === p.damage_level ? null : level,
                       })
                     }
                   >

--- a/frontend/src/components/report-details-modal.tsx
+++ b/frontend/src/components/report-details-modal.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import { X } from "lucide-react";
-import { api } from "../utils/api";
+import { useApi } from "../hooks/use-api";
 import type { ReportFeature } from "../pages/dashboard";
 import styles from "./report-details-modal.module.css";
 
@@ -21,6 +21,7 @@ export const ReportDetailsModal = ({
   const photo = p.photo_url ?? p.thumbnail_url;
   const [saving, setSaving] = useState(false);
   const [reviewError, setReviewError] = useState<string | null>(null);
+  const api = useApi();
 
   const sendReview = async (patch: Record<string, string | null>) => {
     setSaving(true);
@@ -102,16 +103,16 @@ export const ReportDetailsModal = ({
               Object.keys(p.follow_up_responses).some(
                 (k) => k !== "location_description",
               ) && (
-              <Field label="Follow-up responses">
-                <ul className={styles.followUpList}>
-                  {Object.entries(p.follow_up_responses)
-                    .filter(([key]) => key !== "location_description")
-                    .map(([key, value]) => (
-                      <li key={key}>{value}</li>
-                    ))}
-                </ul>
-              </Field>
-            )}
+                <Field label="Follow-up responses">
+                  <ul className={styles.followUpList}>
+                    {Object.entries(p.follow_up_responses)
+                      .filter(([key]) => key !== "location_description")
+                      .map(([key, value]) => (
+                        <li key={key}>{value}</li>
+                      ))}
+                  </ul>
+                </Field>
+              )}
           </div>
 
           <div className={styles.review}>

--- a/frontend/src/components/report-details-modal.tsx
+++ b/frontend/src/components/report-details-modal.tsx
@@ -1,18 +1,54 @@
+import { useState } from "react";
 import { X } from "lucide-react";
+import { api } from "../utils/api";
 import type { ReportFeature } from "../pages/dashboard";
 import styles from "./report-details-modal.module.css";
+
+const DAMAGE_LEVELS = ["minimal", "partial", "complete"] as const;
 
 interface ReportDetailsModalProps {
   report: ReportFeature;
   onClose: () => void;
+  onReportUpdated: (updated: ReportFeature) => void;
 }
 
 export const ReportDetailsModal = ({
   report,
   onClose,
+  onReportUpdated,
 }: ReportDetailsModalProps) => {
   const p = report.properties;
   const photo = p.photo_url ?? p.thumbnail_url;
+  const [saving, setSaving] = useState(false);
+  const [reviewError, setReviewError] = useState<string | null>(null);
+
+  const sendReview = async (patch: Record<string, string | null>) => {
+    setSaving(true);
+    setReviewError(null);
+    try {
+      const result = await api(`/reports/${p.id}/review`, {
+        method: "PATCH",
+        body: JSON.stringify(patch),
+      });
+      onReportUpdated({
+        ...report,
+        properties: {
+          ...p,
+          damage_level: result.damage_level,
+          community_damage_level: result.community_damage_level,
+          analyst_damage_level: result.analyst_damage_level,
+          flag_status: result.flag_status,
+          flag_reason: result.flag_reason,
+        },
+      });
+    } catch (err) {
+      setReviewError(
+        err instanceof Error ? err.message : "Failed to save review",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
 
   return (
     <div className={styles.backdrop} onClick={onClose}>
@@ -75,6 +111,94 @@ export const ReportDetailsModal = ({
                     ))}
                 </ul>
               </Field>
+            )}
+          </div>
+
+          <div className={styles.review}>
+            <div className={styles.reviewTitle}>Analyst review</div>
+
+            {p.flag_status && (
+              <div className={styles.flagBanner}>
+                Flagged as {p.flag_status} — excluded from exports
+                {p.flag_reason ? ` (${p.flag_reason})` : ""}
+              </div>
+            )}
+
+            <div className={styles.reviewRow}>
+              <span className={styles.reviewLabel}>Damage level</span>
+              <div className={styles.reviewButtons}>
+                {DAMAGE_LEVELS.map((level) => (
+                  <button
+                    key={level}
+                    type="button"
+                    disabled={saving}
+                    className={`${styles.reviewBtn} ${
+                      p.damage_level === level ? styles.reviewBtnActive : ""
+                    }`}
+                    onClick={() =>
+                      sendReview({
+                        analyst_damage_level:
+                          level === p.community_damage_level ? null : level,
+                      })
+                    }
+                  >
+                    {level}
+                  </button>
+                ))}
+              </div>
+            </div>
+            {p.analyst_damage_level && (
+              <div className={styles.reviewNote}>
+                Reclassified by analyst — community reported "
+                {p.community_damage_level}".{" "}
+                <button
+                  type="button"
+                  disabled={saving}
+                  className={styles.reviewLink}
+                  onClick={() => sendReview({ analyst_damage_level: null })}
+                >
+                  Restore
+                </button>
+              </div>
+            )}
+
+            <div className={styles.reviewRow}>
+              <span className={styles.reviewLabel}>Flag</span>
+              <div className={styles.reviewButtons}>
+                {p.flag_status ? (
+                  <button
+                    type="button"
+                    disabled={saving}
+                    className={styles.reviewBtn}
+                    onClick={() => sendReview({ flag_status: null })}
+                  >
+                    Remove flag
+                  </button>
+                ) : (
+                  <>
+                    <button
+                      type="button"
+                      disabled={saving}
+                      className={styles.reviewBtn}
+                      onClick={() => sendReview({ flag_status: "suspect" })}
+                    >
+                      Suspect
+                    </button>
+                    <button
+                      type="button"
+                      disabled={saving}
+                      className={styles.reviewBtn}
+                      onClick={() => sendReview({ flag_status: "invalid" })}
+                    >
+                      Invalid
+                    </button>
+                  </>
+                )}
+              </div>
+            </div>
+
+            {reviewError && (
+              <div className={styles.reviewError}>{reviewError}</div>
             )}
           </div>
         </div>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -35,6 +35,10 @@ export interface ReportFeature {
     submitted_at: string;
     version_count: number;
     follow_up_responses: Record<string, string> | null;
+    community_damage_level: string;
+    analyst_damage_level: string | null;
+    flag_status: "suspect" | "invalid" | null;
+    flag_reason: string | null;
   };
 }
 
@@ -292,6 +296,15 @@ const DashboardPage = () => {
         <ReportDetailsModal
           report={detailsReport}
           onClose={() => setDetailsReport(null)}
+          onReportUpdated={(updated) => {
+            setReports((prev) =>
+              prev.map((r) => (r.properties.id === updated.properties.id ? updated : r)),
+            );
+            setDetailsReport(updated);
+            setSelectedReport((prev) =>
+              prev?.properties.id === updated.properties.id ? updated : prev,
+            );
+          }}
         />
       )}
     </div>

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -9,7 +9,7 @@ resource "aws_apigatewayv2_api" "api" {
       "http://localhost:5173",
       "http://localhost:4173",
     ]
-    allow_methods = ["GET", "POST", "PUT", "DELETE", "OPTIONS"]
+    allow_methods = ["GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS"]
     allow_headers = ["Content-Type", "Authorization"]
     max_age       = 3600
   }
@@ -146,6 +146,14 @@ resource "aws_apigatewayv2_route" "put_crisis_event" {
 resource "aws_apigatewayv2_route" "delete_crisis_event" {
   api_id             = aws_apigatewayv2_api.api.id
   route_key          = "DELETE /crisis-events/{event_id}"
+  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+resource "aws_apigatewayv2_route" "patch_report_review" {
+  api_id             = aws_apigatewayv2_api.api.id
+  route_key          = "PATCH /reports/{report_id}/review"
   target             = "integrations/${aws_apigatewayv2_integration.api.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id


### PR DESCRIPTION
## What was built

Two analyst trust tools surfaced in the report details modal on the dashboard:

**Damage reclassification (#169):** An analyst can override the community-submitted damage level (minimal / partial / complete). The override is stored in a new `analyst_damage_level` column and the effective level (`COALESCE(analyst_damage_level, damage_level)`) is used everywhere the data flows — the reports filter, the coverage endpoint, and exports. Clicking the already-active damage button sends `null` to clear the override and restore the community reading. The modal shows a "Reclassified by analyst — community reported X. Restore" note when an override is active.

**Report flagging (#170):** An analyst can flag a report as "Suspect" or "Invalid". Flagged reports display a red banner in the modal and are excluded from all CSV/GeoJSON exports (`WHERE flag_status IS NULL`). The flag can be removed with a "Remove flag" button.

Both actions call a new `PATCH /reports/{id}/review` endpoint, which returns the updated effective fields so the dashboard state refreshes immediately without a reload.

## Scope decisions

- `analyst_damage_level` never overwrites `damage_level` (community voice preserved).
- No per-report audit log or analyst identity tracking — both are valid enhancements but out of scope for the challenge brief.
- No separate "flag reason" UI input — the `flag_reason` column exists and the API accepts it, but the current modal only exposes Suspect / Invalid buttons. A reason field could be added later.
- The new PATCH endpoint validates allowed values server-side (`REVIEW_DAMAGE_LEVELS`, `REVIEW_FLAG_STATUSES` constants) and guards flag_reason: a non-null reason without a flag_status in the same request is rejected 400.

## DB migration

`db/010_analyst_review.sql` — adds `analyst_damage_level`, `flag_status`, `flag_reason` columns and a partial index on `flag_status`.

Apply to Supabase before deploying.

## Manual test checklist

1. Open dashboard → click any report pin → modal opens
2. Click a damage level different from the current → badge updates, "Reclassified" note appears
3. Click the now-active damage level button → override cleared, badge reverts to community value
4. Click "Suspect" → red flag banner appears, flag buttons replaced by "Remove flag"
5. Click "Remove flag" → banner gone, flag buttons reappear
6. Export CSV/GeoJSON with a flagged report in the dataset → flagged report absent from file
7. Damage-level filter on dashboard filters by effective (analyst-overridden) level

Closes #169
Closes #170