### PR TITLE
fix: disable marker pointer events while polygon draw mode is active

### DIFF
--- a/frontend/src/components/dashboard-map.tsx
+++ b/frontend/src/components/dashboard-map.tsx
@@ -54,6 +54,7 @@ export const DashboardMap = ({
   const onPolygonFilterRef = useRef(onPolygonFilter);
   const drawRef = useRef<TerraDraw | null>(null);
   const [drawMode, setDrawMode] = useState<"idle" | "drawing" | "active">("idle");
+  const drawModeRef = useRef<"idle" | "drawing" | "active">("idle");
   const [showBuildings, setShowBuildings] = useState(true);
   const [showCrisis, setShowCrisis] = useState(true);
   const [basemap, setBasemap] = useState<"street" | "satellite">("street");
@@ -65,6 +66,10 @@ export const DashboardMap = ({
   useEffect(() => {
     onPolygonFilterRef.current = onPolygonFilter;
   }, [onPolygonFilter]);
+
+  useEffect(() => {
+    drawModeRef.current = drawMode;
+  }, [drawMode]);
 
   useEffect(() => {
     reportsByIdRef.current = new Map(reports.map((r) => [r.properties.id, r]));
@@ -390,6 +395,7 @@ export const DashboardMap = ({
 
       // Click cluster to zoom in
       map.on("click", "clusters", (e) => {
+        if (drawModeRef.current === "drawing") return;
         const features = map.queryRenderedFeatures(e.point, {
           layers: ["clusters"],
         });
@@ -409,6 +415,7 @@ export const DashboardMap = ({
 
       // Click individual marker to select
       map.on("click", "report-markers", (e) => {
+        if (drawModeRef.current === "drawing") return;
         const feature = e.features?.[0];
         if (!feature?.properties?.id) return;
         const report = reportsByIdRef.current.get(feature.properties.id);
@@ -438,6 +445,7 @@ export const DashboardMap = ({
 
       // Pointer cursors + hover tooltips
       map.on("mouseenter", "clusters", (e) => {
+        if (drawModeRef.current === "drawing") return;
         map.getCanvas().style.cursor = "pointer";
         const feature = e.features?.[0];
         const tip = tooltipRef.current;
@@ -456,6 +464,7 @@ export const DashboardMap = ({
         if (tooltipRef.current) tooltipRef.current.style.display = "none";
       });
       map.on("mouseenter", "report-markers", (e) => {
+        if (drawModeRef.current === "drawing") return;
         map.getCanvas().style.cursor = "pointer";
         const feature = e.features?.[0];
         const tip = tooltipRef.current;


### PR DESCRIPTION
## What

When drawing a polygon on the dashboard map, clicking on a cluster or report marker was intercepting the draw — clusters zoomed the view, individual markers opened a popup and fired the report-selection handler.

## Why this scope

The map event handlers (`click` on `clusters` and `report-markers`, `mouseenter` on both) are registered once inside `map.on("load")` and hold stale closures — they have no direct visibility into React state. The fix adds a `drawModeRef` that mirrors the `drawMode` state via a `useEffect`, making the current mode readable from inside those stale handlers. Four one-line guards (`if (drawModeRef.current === "drawing") return;`) block the problematic interactions while draw is active. Nothing fires differently outside draw mode.

## Manual test (requires live site — Cognito auth blocks localhost)

Verify on `https://terra.foad.dev/dashboard` after deploy:

- [ ] Click **Draw area** and start placing vertices
- [ ] While mid-draw, hover a report marker — cursor stays as draw crosshair, no pointer cursor, no tooltip
- [ ] While mid-draw, click a cluster — places a draw vertex, does NOT zoom
- [ ] Complete the polygon — draw finishes normally
- [ ] Click **Clear area**, then click a marker — popup appears as normal (guard only active during draw)

Closes #215