### PR TITLE
Add nav links between Dashboard and Crisis Management in analyst AppBar

### DIFF
--- a/frontend/src/components/app-bar.module.css
+++ b/frontend/src/components/app-bar.module.css
@@ -7,8 +7,9 @@
 
 .inner {
   display: flex;
-  align-items: baseline;
-  gap: 12px;
+  align-items: center;
+  gap: 8px 12px;
+  flex-wrap: wrap;
 }
 
 .title {
@@ -19,15 +20,37 @@
   line-height: 1;
 }
 
-.subtitle {
+.nav {
+  display: flex;
+  gap: 4px;
+  flex-wrap: wrap;
+}
+
+.navLink {
+  color: inherit;
+  text-decoration: none;
   font-size: 0.8125rem;
-  opacity: 0.8;
+  padding: 4px 8px;
+  border-radius: 3px;
+  opacity: 0.75;
+  white-space: nowrap;
+}
+
+.navLink:hover {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.12);
+}
+
+.navLinkActive {
+  opacity: 1;
+  background: rgba(255, 255, 255, 0.18);
+  font-weight: 600;
 }
 
 .userArea {
   margin-inline-start: auto;
   display: inline-flex;
-  align-items: baseline;
+  align-items: center;
   gap: 12px;
   font-size: 0.8125rem;
 }

--- a/frontend/src/components/app-bar.tsx
+++ b/frontend/src/components/app-bar.tsx
@@ -1,12 +1,8 @@
 import { useAuth } from "react-oidc-context";
-import { useNavigate } from "react-router";
+import { NavLink, useNavigate } from "react-router";
 import styles from "./app-bar.module.css";
 
-interface AppBarProps {
-  subtitle: string;
-}
-
-export const AppBar = ({ subtitle }: AppBarProps) => {
+export const AppBar = () => {
   const auth = useAuth();
   const navigate = useNavigate();
   const email =
@@ -14,11 +10,21 @@ export const AppBar = ({ subtitle }: AppBarProps) => {
     (auth.user?.profile?.["cognito:username"] as string | undefined) ??
     null;
 
+  const navClass = ({ isActive }: { isActive: boolean }) =>
+    `${styles.navLink}${isActive ? ` ${styles.navLinkActive}` : ""}`;
+
   return (
     <header className={styles.bar}>
       <div className={styles.inner}>
         <h1 className={styles.title}>TERRA</h1>
-        <span className={styles.subtitle}>{subtitle}</span>
+        <nav className={styles.nav}>
+          <NavLink to="/dashboard" className={navClass}>
+            Dashboard
+          </NavLink>
+          <NavLink to="/admin/crises" className={navClass}>
+            Crisis Management
+          </NavLink>
+        </nav>
         {email && (
           <span className={styles.userArea}>
             <span className={styles.email}>{email}</span>

--- a/frontend/src/pages/admin-crises.tsx
+++ b/frontend/src/pages/admin-crises.tsx
@@ -187,7 +187,7 @@ const AdminCrisesPage = () => {
   if (editing) {
     return (
       <>
-        <AppBar subtitle="Crisis Management" />
+        <AppBar />
         <CrisisForm
           initial={editing === "new" ? null : editing}
           onCancel={() => setEditing(null)}

--- a/frontend/src/pages/admin-crises.tsx
+++ b/frontend/src/pages/admin-crises.tsx
@@ -202,7 +202,7 @@ const AdminCrisesPage = () => {
 
   return (
     <>
-      <AppBar subtitle="Crisis Management" />
+      <AppBar />
       <div className={styles.container}>
         <header className={styles.header}>
           <h1 className={styles.title}>Crisis events</h1>

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -218,7 +218,7 @@ const DashboardPage = () => {
 
   return (
     <div className={styles.container}>
-      <AppBar subtitle="Dashboard" />
+      <AppBar />
       <div className={styles.statsBar}>
         <div className={styles.statItem}>
           <span


### PR DESCRIPTION
## What

Adds `Dashboard` and `Crisis Management` nav links to the shared `AppBar` component. The active route is visually highlighted (slightly brighter, bolder weight). Removes the now-redundant static `subtitle` prop and both call sites.

**Files changed:** `app-bar.tsx`, `app-bar.module.css`, `dashboard.tsx`, `admin-crises.tsx` — no routing, backend, or dependency changes.

Closes #224

## Why this scope

The two analyst surfaces shared an AppBar with zero navigation between them — evaluators following the test script had to hand-type `/admin/crises`. One click is a lot more convincing than a URL in a test script.

## Manual test checklist

- [ ] `/dashboard` — "Dashboard" link is highlighted; "Crisis Management" is dimmer
- [ ] `/admin/crises` — "Crisis Management" link is highlighted; "Dashboard" is dimmer
- [ ] Clicking each link navigates without a full page reload
- [ ] At desktop width: TERRA + both links + email + Sign out all fit on one row without overflow
- [ ] At ~390px width: layout wraps gracefully (links drop below TERRA) — no clipping