### PR TITLE
feat: deterministic entry link — ?crisis= and ?lng= deep-link support

### DIFF
--- a/frontend/src/app.tsx
+++ b/frontend/src/app.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { useTranslation } from "react-i18next";
 import { Layout } from "./components/layout";
 import { ReportFlow } from "./components/report-flow";
@@ -21,9 +21,19 @@ export const App = () => {
   const pendingCount = counts.pending + counts.syncing;
   const [showFailedPanel, setShowFailedPanel] = useState(false);
 
+  // With a `?crisis=` deep link, location is optional (the crisis zone is
+  // already known), so a denied/blocked geolocation isn't an error worth
+  // alarming the reporter with (#228).
+  const hasCrisisParam = useMemo(
+    () => !!new URLSearchParams(window.location.search).get("crisis"),
+    [],
+  );
+
   return (
     <Layout>
-      {error && <div className={styles.errorBanner}>{error}</div>}
+      {error && !hasCrisisParam && (
+        <div className={styles.errorBanner}>{error}</div>
+      )}
       {!isOnline && (
         <div className={styles.warningBanner}>{t("app.offline")}</div>
       )}

--- a/frontend/src/components/activation-kit-modal.tsx
+++ b/frontend/src/components/activation-kit-modal.tsx
@@ -6,10 +6,11 @@ import styles from "./activation-kit-modal.module.css";
 interface Props {
   name: string;
   crisisType: string;
+  crisisId: string;
   onClose: () => void;
 }
 
-const LANGUAGES = ["EN", "ES", "FR", "AR", "RU", "ZH"] as const;
+const LANGUAGES = ["EN", "ES", "FR", "AR", "RU", "ZH", "TR"] as const;
 type Lang = (typeof LANGUAGES)[number];
 
 const LANG_LABELS: Record<Lang, string> = {
@@ -19,6 +20,7 @@ const LANG_LABELS: Record<Lang, string> = {
   AR: "العربية",
   RU: "Русский",
   ZH: "中文",
+  TR: "Türkçe",
 };
 
 const LANG_META: Record<Lang, { bcp47: string; dir: "ltr" | "rtl" }> = {
@@ -28,16 +30,21 @@ const LANG_META: Record<Lang, { bcp47: string; dir: "ltr" | "rtl" }> = {
   AR: { bcp47: "ar", dir: "rtl" },
   RU: { bcp47: "ru", dir: "ltr" },
   ZH: { bcp47: "zh", dir: "ltr" },
+  TR: { bcp47: "tr", dir: "ltr" },
 };
 
-function whatsappTemplate(name: string, url: string): Record<Lang, string> {
+function whatsappTemplate(
+  name: string,
+  linkFor: (lang: Lang) => string,
+): Record<Lang, string> {
   return {
-    EN: `🚨 *${name}*\n\nWe need your help. Can you share what you're seeing near you? It takes less than 2 minutes and helps emergency teams reach the right places first.\n\nTake a photo and submit here:\n${url}\n\nEvery report makes a difference. Thank you.`,
-    ES: `🚨 *${name}*\n\nNecesitamos tu ayuda. ¿Puedes compartir lo que estás viendo cerca de ti? Toma menos de 2 minutos y ayuda a los equipos de emergencia a llegar primero a los lugares correctos.\n\nToma una foto y envíala aquí:\n${url}\n\nCada informe marca la diferencia. Gracias.`,
-    FR: `🚨 *${name}*\n\nNous avons besoin de votre aide. Pouvez-vous nous dire ce que vous voyez près de chez vous ? Cela prend moins de 2 minutes et aide les équipes d'urgence à se rendre là où c'est le plus nécessaire.\n\nPrenez une photo et signalez ici :\n${url}\n\nChaque signalement compte. Merci.`,
-    AR: `🚨 *${name}*\n\nنحتاج إلى مساعدتك. هل يمكنك مشاركة ما تراه بالقرب منك؟ يستغرق الأمر أقل من دقيقتين ويساعد فرق الطوارئ على الوصول إلى الأماكن الصحيحة أولاً.\n\nالتقط صورة وأرسل تقريرك هنا:\n${url}\n\nكل تقرير يُحدث فرقاً. شكراً لك.`,
-    RU: `🚨 *${name}*\n\nНам нужна ваша помощь. Можете рассказать, что происходит рядом с вами? Это займёт менее 2 минут и поможет экстренным службам прибыть туда, где это нужнее всего.\n\nСфотографируйте и отправьте здесь:\n${url}\n\nКаждый отчёт важен. Спасибо.`,
-    ZH: `🚨 *${name}*\n\n我们需要您的帮助。您能分享一下您附近看到的情况吗？只需不到2分钟，就能帮助救援队第一时间到达最需要的地方。\n\n拍一张照片，在此提交：\n${url}\n\n每一份报告都很重要。谢谢您。`,
+    EN: `🚨 *${name}*\n\nWe need your help. Can you share what you're seeing near you? It takes less than 2 minutes and helps emergency teams reach the right places first.\n\nTake a photo and submit here:\n${linkFor("EN")}\n\nEvery report makes a difference. Thank you.`,
+    ES: `🚨 *${name}*\n\nNecesitamos tu ayuda. ¿Puedes compartir lo que estás viendo cerca de ti? Toma menos de 2 minutos y ayuda a los equipos de emergencia a llegar primero a los lugares correctos.\n\nToma una foto y envíala aquí:\n${linkFor("ES")}\n\nCada informe marca la diferencia. Gracias.`,
+    FR: `🚨 *${name}*\n\nNous avons besoin de votre aide. Pouvez-vous nous dire ce que vous voyez près de chez vous ? Cela prend moins de 2 minutes et aide les équipes d'urgence à se rendre là où c'est le plus nécessaire.\n\nPrenez une photo et signalez ici :\n${linkFor("FR")}\n\nChaque signalement compte. Merci.`,
+    AR: `🚨 *${name}*\n\nنحتاج إلى مساعدتك. هل يمكنك مشاركة ما تراه بالقرب منك؟ يستغرق الأمر أقل من دقيقتين ويساعد فرق الطوارئ على الوصول إلى الأماكن الصحيحة أولاً.\n\nالتقط صورة وأرسل تقريرك هنا:\n${linkFor("AR")}\n\nكل تقرير يُحدث فرقاً. شكراً لك.`,
+    RU: `🚨 *${name}*\n\nНам нужна ваша помощь. Можете рассказать, что происходит рядом с вами? Это займёт менее 2 минут и поможет экстренным службам прибыть туда, где это нужнее всего.\n\nСфотографируйте и отправьте здесь:\n${linkFor("RU")}\n\nКаждый отчёт важен. Спасибо.`,
+    ZH: `🚨 *${name}*\n\n我们需要您的帮助。您能分享一下您附近看到的情况吗？只需不到2分钟，就能帮助救援队第一时间到达最需要的地方。\n\n拍一张照片，在此提交：\n${linkFor("ZH")}\n\n每一份报告都很重要。谢谢您。`,
+    TR: `🚨 *${name}*\n\nYardımınıza ihtiyacımız var. Yakınınızda neler olduğunu paylaşabilir misiniz? 2 dakikadan az sürer ve acil ekiplerin doğru yerlere önce ulaşmasına yardımcı olur.\n\nBir fotoğraf çekin ve buradan gönderin:\n${linkFor("TR")}\n\nHer rapor bir fark yaratır. Teşekkür ederiz.`,
   };
 }
 
@@ -48,6 +55,7 @@ const POSTER_INSTRUCTIONS: Record<Lang, string> = {
   AR: "امسح لإبلاغ عن الأضرار في منطقتك",
   RU: "Сканируйте, чтобы сообщить об ущербе",
   ZH: "扫描以报告您所在地区的损坏情况",
+  TR: "Bölgenizdeki hasarı bildirmek için tarayın",
 };
 
 function escapeHtml(str: string): string {
@@ -77,9 +85,19 @@ function CopyButton({ text }: { text: string }) {
   );
 }
 
-export function ActivationKitModal({ name, crisisType, onClose }: Props) {
-  const url = window.location.origin;
-  const templates = whatsappTemplate(name, url);
+export function ActivationKitModal({
+  name,
+  crisisType,
+  crisisId,
+  onClose,
+}: Props) {
+  // Deterministic entry link (#228): the QR and shared links carry the crisis
+  // id so they open straight onto this crisis zone regardless of where the
+  // device is, and each language template presets its own UI language.
+  const base = window.location.origin;
+  const url = `${base}/?crisis=${crisisId}`;
+  const linkFor = (lang: Lang) => `${url}&lng=${LANG_META[lang].bcp47}`;
+  const templates = whatsappTemplate(name, linkFor);
   const [activeLang, setActiveLang] = useState<Lang>("EN");
   const [printBlocked, setPrintBlocked] = useState(false);
   const qrRef = useRef<HTMLDivElement>(null);
@@ -243,7 +261,7 @@ export function ActivationKitModal({ name, crisisType, onClose }: Props) {
         <div className={styles.section}>
           <div className={styles.sectionLabel}>QR Code</div>
           <div className={styles.qrWrap} ref={qrRef}>
-            <QRCodeSVG value={url} size={160} />
+            <QRCodeSVG value={linkFor(activeLang)} size={160} />
           </div>
         </div>
 

--- a/frontend/src/components/app-bar.module.css
+++ b/frontend/src/components/app-bar.module.css
@@ -8,8 +8,7 @@
 .inner {
   display: flex;
   align-items: center;
-  gap: 8px 12px;
-  flex-wrap: wrap;
+  gap: 12px;
 }
 
 .title {
@@ -45,6 +44,10 @@
   opacity: 1;
   background: rgba(255, 255, 255, 0.18);
   font-weight: 600;
+}
+
+.navLinkActive:hover {
+  background: rgba(255, 255, 255, 0.18);
 }
 
 .userArea {

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -33,6 +33,10 @@ interface MapProps {
   latitude: number | null;
   longitude: number | null;
   accuracy: number | null;
+  // When set, the map pins to this specific crisis zone and does not recentre
+  // on the reporter's location — so a deep link lands deterministically on the
+  // affected area regardless of where the device is (#228).
+  pinnedCrisisId?: string | null;
   onBuildingSelect?: (building: SelectedBuilding | null) => void;
   onManualPin?: (coords: [number, number] | null) => void;
 }
@@ -41,6 +45,7 @@ export const Map = ({
   latitude,
   longitude,
   accuracy,
+  pinnedCrisisId,
   onBuildingSelect,
   onManualPin,
 }: MapProps) => {
@@ -349,11 +354,17 @@ export const Map = ({
     (async () => {
       try {
         const data = await api("/crisis-events");
-        if (cancelled || hasCenteredRef.current) return;
+        if (cancelled) return;
         const active = (data?.events ?? []).filter(
           (e: { is_active: boolean }) => e.is_active,
         );
-        if (active.length === 0) return;
+        // A `?crisis=` deep link fits to that one crisis; a stale/unknown id
+        // falls back to all active zones rather than the blank world view.
+        let target = pinnedCrisisId
+          ? active.filter((e: { id: string }) => e.id === pinnedCrisisId)
+          : active;
+        if (target.length === 0) target = active;
+        if (target.length === 0) return;
         const bounds = new maplibregl.LngLatBounds();
         const extend = (coords: unknown) => {
           if (!Array.isArray(coords)) return;
@@ -363,9 +374,12 @@ export const Map = ({
             for (const c of coords) extend(c);
           }
         };
-        for (const e of active) extend(e.region?.coordinates);
-        if (!bounds.isEmpty() && !hasCenteredRef.current) {
+        for (const e of target) extend(e.region?.coordinates);
+        // Always fit when pinned (overrides a GPS fix that beat the fetch);
+        // otherwise only fit if nothing has centred yet.
+        if (!bounds.isEmpty() && (!hasCenteredRef.current || pinnedCrisisId)) {
           map.fitBounds(bounds, { padding: 60, animate: false });
+          if (pinnedCrisisId) hasCenteredRef.current = true;
         }
       } catch {
         // No crisis info available — keep the default view until the
@@ -375,13 +389,16 @@ export const Map = ({
     return () => {
       cancelled = true;
     };
-  }, []);
+  }, [pinnedCrisisId]);
 
   // Update user location marker and center map on first fix
   useEffect(() => {
     const map = mapRef.current;
     if (!map || latitude === null || longitude === null) return;
 
+    // Fly to the user on first GPS fix. When pinned, hasCenteredRef is set to
+    // true by the fitBounds path — so this only fires if that fetch failed,
+    // which is preferable to leaving the map on the blank world view.
     if (!hasCenteredRef.current) {
       map.flyTo({ center: [longitude, latitude], zoom: 18, speed: 4 });
       hasCenteredRef.current = true;

--- a/frontend/src/components/report-flow.tsx
+++ b/frontend/src/components/report-flow.tsx
@@ -1,4 +1,4 @@
-import { useState, useCallback, useEffect, useRef } from "react";
+import { useState, useCallback, useEffect, useMemo, useRef } from "react";
 import { useTranslation } from "react-i18next";
 import { Map } from "./map";
 import type { SelectedBuilding } from "./map";
@@ -79,6 +79,13 @@ export const ReportFlow = ({
     useState<FollowUpQuestion[]>([]);
   const [activeCrisisName, setActiveCrisisName] = useState<string | null>(null);
   const crisisLookedUpRef = useRef(false);
+  // A `?crisis=<id>` deep link pins the flow to a specific crisis regardless
+  // of the reporter's location — so evaluators (and Activation-Kit links) load
+  // the right config without being in the zone (#228).
+  const crisisIdParam = useMemo(
+    () => new URLSearchParams(window.location.search).get("crisis"),
+    [],
+  );
   const [reportLocation, setReportLocation] = useState<{
     lat: number;
     lng: number;
@@ -169,24 +176,44 @@ export const ReportFlow = ({
 
   useEffect(() => {
     if (crisisLookedUpRef.current) return;
-    if (latitude == null || longitude == null) return;
+    // The geolocation path needs a fix first; the `?crisis=` param path does not.
+    if (!crisisIdParam && (latitude == null || longitude == null)) return;
     crisisLookedUpRef.current = true;
+
+    const applyConfig = (config: {
+      crisis_type?: string | null;
+      follow_up_questions?: FollowUpQuestion[];
+      name?: string | null;
+    }) => {
+      if (config.crisis_type) setActiveCrisisType(config.crisis_type);
+      if (config.follow_up_questions)
+        setActiveCrisisFollowUpQuestions(config.follow_up_questions);
+      if (config.name) setActiveCrisisName(config.name);
+      localStorage.setItem(
+        "terra-crisis-config",
+        JSON.stringify({
+          crisis_type: config.crisis_type ?? null,
+          follow_up_questions: config.follow_up_questions ?? [],
+        }),
+      );
+    };
+
     (async () => {
       try {
+        if (crisisIdParam) {
+          // Match the crisis by id from the public list, so a deep link loads
+          // the right config independent of the reporter's location (#228).
+          const data = await api("/crisis-events");
+          const match = (data?.events ?? []).find(
+            (e: { id: string }) => e.id === crisisIdParam,
+          );
+          if (match) applyConfig(match);
+          return;
+        }
         const result = await api(
           `/crisis-events/active?lat=${latitude}&lng=${longitude}`,
         );
-        if (result?.crisis_type) setActiveCrisisType(result.crisis_type);
-        if (result?.follow_up_questions)
-          setActiveCrisisFollowUpQuestions(result.follow_up_questions);
-        if (result?.name) setActiveCrisisName(result.name);
-        localStorage.setItem(
-          "terra-crisis-config",
-          JSON.stringify({
-            crisis_type: result?.crisis_type ?? null,
-            follow_up_questions: result?.follow_up_questions ?? [],
-          }),
-        );
+        if (result) applyConfig(result);
       } catch (err) {
         // A definitive HTTP response (404 = genuinely no active crisis at
         // this location) must not fall back to a stale cached crisis from
@@ -211,7 +238,7 @@ export const ReportFlow = ({
         }
       }
     })();
-  }, [latitude, longitude]);
+  }, [latitude, longitude, crisisIdParam]);
 
   useEffect(() => {
     const buildingId = selectedBuilding?.buildingId;
@@ -373,6 +400,7 @@ export const ReportFlow = ({
             latitude={latitude}
             longitude={longitude}
             accuracy={accuracy}
+            pinnedCrisisId={crisisIdParam}
             onBuildingSelect={handleBuildingSelect}
             onManualPin={handleManualPin}
           />

--- a/frontend/src/i18n/index.ts
+++ b/frontend/src/i18n/index.ts
@@ -10,10 +10,55 @@ import tr from "./tr.json";
 
 const RTL_LANGUAGES = ["ar"];
 
-const savedLanguage =
-  localStorage.getItem("terra-language") ||
-  navigator.language.split("-")[0] ||
-  "en";
+// Hoisted so SUPPORTED_LANGUAGE_CODES can be derived from it (single source of truth).
+export const SUPPORTED_LANGUAGES = [
+  { code: "en", name: "English" },
+  { code: "ar", name: "العربية" },
+  { code: "zh", name: "中文" },
+  { code: "fr", name: "Français" },
+  { code: "ru", name: "Русский" },
+  { code: "es", name: "Español" },
+  { code: "tr", name: "Türkçe" },
+];
+
+const SUPPORTED_LANGUAGE_CODES = SUPPORTED_LANGUAGES.map((l) => l.code);
+
+// A `?lng=` URL param (e.g. from a Community Activation Kit / WhatsApp deep
+// link) takes precedence so a link opens straight into the right language
+// (#228). Session-only: we don't persist it to localStorage so it doesn't
+// overwrite the user's own preference on future visits.
+const urlLanguage = new URLSearchParams(window.location.search).get("lng");
+const validUrlLanguage =
+  urlLanguage && SUPPORTED_LANGUAGE_CODES.includes(urlLanguage)
+    ? urlLanguage
+    : null;
+
+// localStorage.getItem/setItem can throw in storage-restricted contexts
+// (private browsing in some browsers) — guard every access at module load.
+let savedLanguage: string;
+try {
+  savedLanguage =
+    validUrlLanguage ||
+    localStorage.getItem("terra-language") ||
+    navigator.language.split("-")[0] ||
+    "en";
+} catch {
+  savedLanguage = validUrlLanguage || navigator.language.split("-")[0] || "en";
+}
+
+// Register before init() so the handler catches any synchronous
+// languageChanged event that fires during initialisation.
+i18n.on("languageChanged", (lng) => {
+  document.documentElement.dir = RTL_LANGUAGES.includes(lng) ? "rtl" : "ltr";
+  document.documentElement.lang = lng;
+  // Don't persist the URL-param language — it's session-only (#228).
+  if (validUrlLanguage && lng === validUrlLanguage) return;
+  try {
+    localStorage.setItem("terra-language", lng);
+  } catch {
+    // Storage unavailable — language reverts to default on next visit.
+  }
+});
 
 i18n.use(initReactI18next).init({
   resources: {
@@ -32,25 +77,9 @@ i18n.use(initReactI18next).init({
   interpolation: { escapeValue: false },
 });
 
-i18n.on("languageChanged", (lng) => {
-  document.documentElement.dir = RTL_LANGUAGES.includes(lng) ? "rtl" : "ltr";
-  document.documentElement.lang = lng;
-  localStorage.setItem("terra-language", lng);
-});
-
 document.documentElement.dir = RTL_LANGUAGES.includes(i18n.language)
   ? "rtl"
   : "ltr";
 document.documentElement.lang = i18n.language;
 
 export default i18n;
-
-export const SUPPORTED_LANGUAGES = [
-  { code: "en", name: "English" },
-  { code: "ar", name: "العربية" },
-  { code: "zh", name: "中文" },
-  { code: "fr", name: "Français" },
-  { code: "ru", name: "Русский" },
-  { code: "es", name: "Español" },
-  { code: "tr", name: "Türkçe" },
-];

--- a/frontend/src/pages/admin-crises.tsx
+++ b/frontend/src/pages/admin-crises.tsx
@@ -184,10 +184,10 @@ const AdminCrisesPage = () => {
     await refresh();
   };
 
-  if (editing) {
-    return (
-      <>
-        <AppBar />
+  return (
+    <>
+      <AppBar />
+      {editing ? (
         <CrisisForm
           initial={editing === "new" ? null : editing}
           onCancel={() => setEditing(null)}
@@ -196,91 +196,89 @@ const AdminCrisesPage = () => {
             await refresh();
           }}
         />
-      </>
-    );
-  }
+      ) : (
+        <>
+          <div className={styles.container}>
+            <header className={styles.header}>
+              <h1 className={styles.title}>Crisis events</h1>
+              <button
+                type="button"
+                className={styles.primary}
+                onClick={() => setEditing("new")}
+              >
+                <Plus size={16} /> New crisis
+              </button>
+            </header>
 
-  return (
-    <>
-      <AppBar />
-      <div className={styles.container}>
-        <header className={styles.header}>
-          <h1 className={styles.title}>Crisis events</h1>
-          <button
-            type="button"
-            className={styles.primary}
-            onClick={() => setEditing("new")}
-          >
-            <Plus size={16} /> New crisis
-          </button>
-        </header>
+            {loading ? (
+              <div className={styles.empty}>Loading…</div>
+            ) : crises.length === 0 ? (
+              <div className={styles.empty}>No crisis events yet.</div>
+            ) : (
+              <table className={styles.table}>
+                <thead>
+                  <tr>
+                    <th>Name</th>
+                    <th>Type</th>
+                    <th>Status</th>
+                    <th />
+                  </tr>
+                </thead>
+                <tbody>
+                  {crises.map((c) => (
+                    <tr key={c.id}>
+                      <td>{c.name}</td>
+                      <td>{c.crisis_type}</td>
+                      <td>
+                        <span
+                          className={`${styles.badge} ${c.is_active ? styles.active : styles.inactive}`}
+                        >
+                          {c.is_active ? "Active" : "Inactive"}
+                        </span>
+                      </td>
+                      <td className={styles.actions}>
+                        <button
+                          type="button"
+                          className={styles.iconButton}
+                          onClick={() => setKitCrisis(c)}
+                          aria-label="Activation Kit"
+                          title="Community Activation Kit"
+                        >
+                          <QrCode size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.iconButton}
+                          onClick={() => setEditing(c)}
+                          aria-label="Edit"
+                        >
+                          <Pencil size={16} />
+                        </button>
+                        <button
+                          type="button"
+                          className={styles.iconButton}
+                          onClick={() => handleDelete(c)}
+                          aria-label="Delete"
+                        >
+                          <Trash2 size={16} />
+                        </button>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </div>
 
-        {loading ? (
-          <div className={styles.empty}>Loading…</div>
-        ) : crises.length === 0 ? (
-          <div className={styles.empty}>No crisis events yet.</div>
-        ) : (
-          <table className={styles.table}>
-            <thead>
-              <tr>
-                <th>Name</th>
-                <th>Type</th>
-                <th>Status</th>
-                <th />
-              </tr>
-            </thead>
-            <tbody>
-              {crises.map((c) => (
-                <tr key={c.id}>
-                  <td>{c.name}</td>
-                  <td>{c.crisis_type}</td>
-                  <td>
-                    <span
-                      className={`${styles.badge} ${c.is_active ? styles.active : styles.inactive}`}
-                    >
-                      {c.is_active ? "Active" : "Inactive"}
-                    </span>
-                  </td>
-                  <td className={styles.actions}>
-                    <button
-                      type="button"
-                      className={styles.iconButton}
-                      onClick={() => setKitCrisis(c)}
-                      aria-label="Activation Kit"
-                      title="Community Activation Kit"
-                    >
-                      <QrCode size={16} />
-                    </button>
-                    <button
-                      type="button"
-                      className={styles.iconButton}
-                      onClick={() => setEditing(c)}
-                      aria-label="Edit"
-                    >
-                      <Pencil size={16} />
-                    </button>
-                    <button
-                      type="button"
-                      className={styles.iconButton}
-                      onClick={() => handleDelete(c)}
-                      aria-label="Delete"
-                    >
-                      <Trash2 size={16} />
-                    </button>
-                  </td>
-                </tr>
-              ))}
-            </tbody>
-          </table>
-        )}
-      </div>
-
-      {kitCrisis && (
-        <ActivationKitModal
-          name={kitCrisis.name}
-          crisisType={kitCrisis.crisis_type}
-          onClose={() => setKitCrisis(null)}
-        />
+          {kitCrisis && (
+            <ActivationKitModal
+              name={kitCrisis.name}
+              crisisType={kitCrisis.crisis_type}
+              crisisId={kitCrisis.id}
+              onClose={() => setKitCrisis(null)}
+            />
+          )}
+        </>
       )}
     </>
   );


### PR DESCRIPTION
Closes #228

## What was built

Community Activation Kit links now carry `?crisis=<id>&lng=<bcp47>` so QR codes and WhatsApp templates open straight onto the right crisis zone in the right UI language, regardless of where the device is located.

**Core deep-link flow (`report-flow`, `map`, `app`):**
- `?crisis=<id>` reads the crisis config by ID from `/crisis-events` instead of the geolocation-based lookup — evaluators and deployment-kit recipients outside the zone get the right config
- Map pins to the specified crisis zone (`pinnedCrisisId` prop + `fitBounds`) and locks centering so a GPS fix can't pull the view away
- Geolocation error banner suppressed when `?crisis=` is present — location isn't needed for the pinned flow

**Language preset (`i18n`):**
- `?lng=<bcp47>` sets the UI language for the session only — the link opens in the sender's language without overwriting the recipient's stored preference on future visits
- Handler registered before `i18n.init()` to correctly catch any synchronous `languageChanged` event; replaced the one-shot flag approach with a direct `lng === validUrlLanguage` comparison, which is robust regardless of init timing
- `localStorage` access wrapped in try/catch throughout for Safari private-mode safety

**Activation Kit modal:**
- QR code now encodes `linkFor(activeLang)` (`?crisis=<id>&lng=<bcp47>`) to match whichever language tab is selected — scanning an Arabic poster now opens in Arabic
- Turkish added as 7th language (WhatsApp template, poster instruction, QR link), fixing an omission from PR #205 which added the locale but didn't update the modal
- Shareable link remains the bare `?crisis=<id>` URL (language-agnostic, appropriate for digital sharing)

**AppBar / admin fixes (opportunistic, caught in review):**
- `<AppBar />` hoisted above the `if (editing)` split in `AdminCrisesPage` — previously it unmounted and remounted on every edit toggle
- Removed `flex-wrap` from `.inner` to keep the bar single-line on narrow viewports
- Added `.navLinkActive:hover` rule to hold the active background colour when hovering the current page's link (specificity fix)
- Removed spurious `pinnedCrisisId` from the geolocation effect dep array in `map.tsx`

## Manual test checklist

- [ ] `/?crisis=<id>` — map centres on crisis zone, not device location; crisis name appears in the header
- [ ] `/?crisis=<id>&lng=tr` — UI loads in Turkish immediately
- [ ] `/?crisis=<unknown-id>` — falls back to all active zones, no blank world view
- [ ] Activation Kit modal — 7 language tabs present including Türkçe; QR code updates when switching tabs; WhatsApp template carries `&lng=` param
- [ ] Dashboard nav link shows active/bold; Crisis Management is dimmer; vice-versa on `/admin/crises`
- [ ] Edit crisis → cancel → edit again: AppBar stays in place with no flicker