### PR TITLE
fix: GPS-in-zone centering and locate-me button

### DIFF
--- a/frontend/src/components/map.module.css
+++ b/frontend/src/components/map.module.css
@@ -66,3 +66,32 @@
 .pinMarker:active {
   cursor: grabbing;
 }
+
+/* "Go to my location" button — mirrors MapLibre's NavigationControl style,
+   positioned below the zoom/compass controls at top-right. */
+.locateButton {
+  position: absolute;
+  top: 120px;
+  right: 10px;
+  width: 29px;
+  height: 29px;
+  background: #fff;
+  border: none;
+  border-radius: 4px;
+  box-shadow: 0 0 0 2px rgba(0, 0, 0, 0.1);
+  cursor: pointer;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: #555;
+  padding: 0;
+  z-index: 1;
+}
+
+.locateButton:hover {
+  background: #f0f0f0;
+}
+
+.locateButton:active {
+  background: #e0e0e0;
+}

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -55,6 +55,9 @@ export const Map = ({
   const markerRef = useRef<maplibregl.Marker | null>(null);
   const pinMarkerRef = useRef<maplibregl.Marker | null>(null);
   const hasCenteredRef = useRef(false);
+  const hasFlownToUserRef = useRef(false);
+  const pinnedCrisisRegionRef = useRef<GeoJSON.Polygon | null>(null);
+  const gpsPositionRef = useRef<[number, number] | null>(null);
   const onBuildingSelectRef = useRef(onBuildingSelect);
   const onManualPinRef = useRef(onManualPin);
   const [coverageCount, setCoverageCount] = useState<{
@@ -340,6 +343,9 @@ export const Map = ({
       markerRef.current = null;
       pinMarkerRef.current = null;
       hasCenteredRef.current = false;
+      hasFlownToUserRef.current = false;
+      pinnedCrisisRegionRef.current = null;
+      gpsPositionRef.current = null;
     };
   }, []);
 
@@ -375,11 +381,20 @@ export const Map = ({
           }
         };
         for (const e of target) extend(e.region?.coordinates);
-        // Always fit when pinned (overrides a GPS fix that beat the fetch);
-        // otherwise only fit if nothing has centred yet.
-        if (!bounds.isEmpty() && (!hasCenteredRef.current || pinnedCrisisId)) {
+        // Store the pinned crisis polygon so the GPS effect can check whether
+        // the user is inside the zone and should override the zone-fit (#228).
+        if (pinnedCrisisId && target.length > 0) {
+          pinnedCrisisRegionRef.current =
+            (target[0].region as GeoJSON.Polygon) ?? null;
+        }
+        // Fit to the crisis zone unless GPS already placed the user inside it.
+        const gpsInZone =
+          pinnedCrisisId && gpsPositionRef.current && pinnedCrisisRegionRef.current
+            ? pointInPolygon(gpsPositionRef.current, pinnedCrisisRegionRef.current)
+            : false;
+        if (!bounds.isEmpty() && (!hasCenteredRef.current || (pinnedCrisisId && !gpsInZone))) {
           map.fitBounds(bounds, { padding: 60, animate: false });
-          if (pinnedCrisisId) hasCenteredRef.current = true;
+          if (pinnedCrisisId && !gpsInZone) hasCenteredRef.current = true;
         }
       } catch {
         // No crisis info available — keep the default view until the
@@ -396,12 +411,20 @@ export const Map = ({
     const map = mapRef.current;
     if (!map || latitude === null || longitude === null) return;
 
-    // Fly to the user on first GPS fix. When pinned, hasCenteredRef is set to
-    // true by the fitBounds path — so this only fires if that fetch failed,
-    // which is preferable to leaving the map on the blank world view.
-    if (!hasCenteredRef.current) {
+    // Keep the GPS position ref current so the crisis effect can check
+    // gps-in-zone even when GPS arrived before the crisis fetch completed.
+    gpsPositionRef.current = [longitude, latitude];
+    // Fly to user on first fix. Also fly if the user is physically inside the
+    // pinned crisis zone — overriding the zone-fit so they see their actual
+    // street-level position rather than the full region bounds (#228).
+    const inCrisisZone =
+      pinnedCrisisId && pinnedCrisisRegionRef.current
+        ? pointInPolygon([longitude, latitude], pinnedCrisisRegionRef.current)
+        : false;
+    if (!hasCenteredRef.current || (inCrisisZone && !hasFlownToUserRef.current)) {
       map.flyTo({ center: [longitude, latitude], zoom: 18, speed: 4 });
       hasCenteredRef.current = true;
+      hasFlownToUserRef.current = true;
     }
 
     if (markerRef.current) {
@@ -437,7 +460,7 @@ export const Map = ({
         BUILDINGS_LAYER,
       );
     }
-  }, [latitude, longitude, accuracy]);
+  }, [latitude, longitude, accuracy, pinnedCrisisId]);
 
   const unassessed =
     coverageCount && coverageCount.total > 0
@@ -447,6 +470,26 @@ export const Map = ({
   return (
     <div className={styles.wrapper}>
       <div ref={containerRef} className={styles.container} />
+      {latitude !== null && longitude !== null && (
+        <button
+          type="button"
+          className={styles.locateButton}
+          onClick={() => {
+            mapRef.current?.flyTo({ center: [longitude, latitude], zoom: 18, speed: 4 });
+          }}
+          title="Go to my location"
+          aria-label="Go to my location"
+        >
+          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+            <circle cx="12" cy="12" r="8"/>
+            <line x1="12" y1="2" x2="12" y2="6"/>
+            <line x1="12" y1="18" x2="12" y2="22"/>
+            <line x1="2" y1="12" x2="6" y2="12"/>
+            <line x1="18" y1="12" x2="22" y2="12"/>
+            <circle cx="12" cy="12" r="2" fill="currentColor" stroke="none"/>
+          </svg>
+        </button>
+      )}
       {unassessed !== null && (
         <div className={styles.coverageBadge}>
           {t("coverage.unassessed", { count: unassessed })}
@@ -455,6 +498,20 @@ export const Map = ({
     </div>
   );
 };
+
+function pointInPolygon(point: [number, number], polygon: GeoJSON.Polygon): boolean {
+  const [x, y] = point;
+  const ring = polygon.coordinates[0];
+  let inside = false;
+  for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
+    const [xi, yi] = ring[i] as [number, number];
+    const [xj, yj] = ring[j] as [number, number];
+    if ((yi > y) !== (yj > y) && x < ((xj - xi) * (y - yi)) / (yj - yi) + xi) {
+      inside = !inside;
+    }
+  }
+  return inside;
+}
 
 const createAccuracyCircle = (
   lng: number,

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -356,6 +356,11 @@ export const Map = ({
   useEffect(() => {
     const map = mapRef.current;
     if (!map) return;
+    // Reset centering state so each new pinnedCrisisId gets a fresh evaluation
+    // rather than inheriting flags set for a previous crisis.
+    hasCenteredRef.current = false;
+    hasFlownToUserRef.current = false;
+    pinnedCrisisRegionRef.current = null;
     let cancelled = false;
     (async () => {
       try {
@@ -369,6 +374,9 @@ export const Map = ({
         let target = pinnedCrisisId
           ? active.filter((e: { id: string }) => e.id === pinnedCrisisId)
           : active;
+        // Capture the exact match BEFORE the fallback may replace target, so
+        // we store the correct polygon even when the id is stale/unknown.
+        const exactMatch = pinnedCrisisId ? (target[0] ?? null) : null;
         if (target.length === 0) target = active;
         if (target.length === 0) return;
         const bounds = new maplibregl.LngLatBounds();
@@ -381,12 +389,10 @@ export const Map = ({
           }
         };
         for (const e of target) extend(e.region?.coordinates);
-        // Store the pinned crisis polygon so the GPS effect can check whether
-        // the user is inside the zone and should override the zone-fit (#228).
-        if (pinnedCrisisId && target.length > 0) {
-          pinnedCrisisRegionRef.current =
-            (target[0].region as GeoJSON.Polygon) ?? null;
-        }
+        // Store only the exact match — if the id was stale, leave ref null so
+        // the gps-in-zone check returns false rather than testing a random zone.
+        pinnedCrisisRegionRef.current =
+          exactMatch ? (exactMatch.region as GeoJSON.Polygon) ?? null : null;
         // Fit to the crisis zone unless GPS already placed the user inside it.
         const gpsInZone =
           pinnedCrisisId && gpsPositionRef.current && pinnedCrisisRegionRef.current
@@ -502,6 +508,7 @@ export const Map = ({
 function pointInPolygon(point: [number, number], polygon: GeoJSON.Polygon): boolean {
   const [x, y] = point;
   const ring = polygon.coordinates[0];
+  if (!ring || ring.length < 3) return false;
   let inside = false;
   for (let i = 0, j = ring.length - 1; i < ring.length; j = i++) {
     const [xi, yi] = ring[i] as [number, number];


### PR DESCRIPTION
## What

Two fixes in response to Dan's review feedback on #230:

**1. GPS-in-zone centering**

When a `?crisis=` deep link is opened by someone physically inside the crisis polygon, the map now flies to their GPS position at street level rather than fitting the entire zone. The previous behaviour always overrode GPS with a zone `fitBounds` when `pinnedCrisisId` was set, which meant real field users got a worse experience than the non-pinned flow.

Implementation: a `pointInPolygon` ray-casting helper coordinates two async effects via three refs (`pinnedCrisisRegionRef`, `gpsPositionRef`, `hasFlownToUserRef`). Both race directions are handled — GPS before fetch and fetch before GPS.

**2. Locate-me button**

A crosshair button (29×29, matches MapLibre control style) sits below the NavigationControl at top-right. Visible only when a GPS fix is available. Tapping it calls `flyTo` back to the user's position. Needed because artificially centring the map on a crisis zone means users need a recovery path.

## Scope decisions

- Point-in-polygon checks the outer ring only — sufficient for all TERRA crisis regions (simple GeoJSON Polygons).
- Button is always shown when GPS is available, not conditional on `pinnedCrisisId` — it's useful anytime the user navigates away from their location.
- No i18n added for the `aria-label` — icon-only button, universally understood crosshair.

## Testing

Playwright screenshots in `scripts/qa-screenshots-dan-feedback.mjs` (port arg: `--port=NNNN`). Covers:
- [ ] GPS outside zone → crisis overview shown
- [ ] GPS inside zone → street-level fly-to, building footprints visible, GPS dot centred
- [ ] No GPS → no locate button rendered
- [ ] Pan away → tap locate button → snaps back to GPS position