### PR TITLE
[#237] Drop heavy COUNT from submission path

### DIFF
--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -266,19 +266,11 @@ def create_report(body: dict) -> dict:
             insert_data,
         )
 
-        # Get area report count
-        cur.execute(
-            "SELECT COUNT(*) FROM reports WHERE h3_r8 = %s",
-            (h3_r8,),
-        )
-        area_count = cur.fetchone()[0]
-
     conn.commit()
 
     return {
         "id": report_id,
         "status": "created",
-        "area_report_count": area_count,
         "version_chain_id": str(version_chain_id),
         "duplicate_status": duplicate_check["duplicate_status"],
         "related_report_id": duplicate_check["related_report_id"],

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -102,11 +102,10 @@ class TestCreateReport:
     def test_creates_report(self, mock_get_conn):
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        # _find_version_chain (building lookup) → None (new chain)
-        # duplicate building check → None (no reassessment)
-        # duplicate location check → None (no duplicate)
-        # area count → 1
-        mock_cursor.fetchone.side_effect = [None, None, None, (1,)]
+        # _find_version_chain (building lookup) -> None (new chain)
+        # duplicate building check -> None (no reassessment)
+        # duplicate location check -> None (no duplicate)
+        mock_cursor.fetchone.side_effect = [None, None, None]
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -115,7 +114,6 @@ class TestCreateReport:
 
         assert result["status"] == "created"
         assert "id" in result
-        assert "area_report_count" in result
         assert "version_chain_id" in result
         mock_conn.commit.assert_called_once()
 
@@ -138,11 +136,10 @@ class TestCreateReport:
     def test_includes_photo_url_when_key_provided(self, mock_get_conn):
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        # _find_version_chain (building lookup) → None (new chain)
-        # duplicate building check → None (no reassessment)
-        # duplicate location check → None (no duplicate)
-        # area count → 1
-        mock_cursor.fetchone.side_effect = [None, None, None, (1,)]
+        # _find_version_chain (building lookup) -> None (new chain)
+        # duplicate building check -> None (no reassessment)
+        # duplicate location check -> None (no duplicate)
+        mock_cursor.fetchone.side_effect = [None, None, None]
         mock_conn.cursor.return_value.__enter__ = lambda _: mock_cursor
         mock_conn.cursor.return_value.__exit__ = MagicMock(return_value=False)
         mock_get_conn.return_value = mock_conn
@@ -153,7 +150,7 @@ class TestCreateReport:
         assert result["status"] == "created"
         # Verify the INSERT was called with photo_url containing the key.
         # Named placeholders mean params is now a dict, not a tuple.
-        insert_call = mock_cursor.execute.call_args_list[-2]
+        insert_call = mock_cursor.execute.call_args_list[-1]
         params = insert_call[0][1]
         assert photo_key in params["photo_url"]
 

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -349,12 +349,13 @@ Submit a damage assessment report.
 {
   "id": "59a7cb76-0b9f-4f45-a91d-e237a3760a31",
   "status": "created",
-  "area_report_count": 12,
   "version_chain_id": "a34b724b-c715-4e37-a81c-8b5ca7ef4d25",
   "duplicate_status": null,
   "related_report_id": null
 }
 ```
+
+The area-count (reports near this location) is fetched separately by the confirmation screen via `GET /reports/coverage?h3=...&limit=1` -> `total`.
 
 `duplicate_status` is one of `null`, `"possible_duplicate"` (another report exists within 15 m and 2 min), or `"reassessment"` (an earlier report exists for the same `building_id`). `related_report_id` references the matched earlier report when `duplicate_status` is non-null.
 

--- a/docs/report-submission-flow.md
+++ b/docs/report-submission-flow.md
@@ -41,7 +41,7 @@ sequenceDiagram
     API->>DB: Find or create version chain (by building_id, fallback H3 r12)
     API->>DB: INSERT report (trigger flips previous versions to is_latest=false)
     API->>DB: SELECT area report count
-    API-->>U: { id, status: created \| duplicate, area_report_count, version_chain_id }
+    API-->>U: { id, status: created \| duplicate, version_chain_id }
     U->>IDB: Mark report synced
     U->>LS: Save survey answers for pre-seeding next report
 


### PR DESCRIPTION
closes #237 

 - We were making a heavy COUNT on submission to retrieve `area_report_count` even though we also got this async on load and post-submit from `GET /reports/coverage?h3=...`
 - Drop this unnecessary call