### PR TITLE
[#238] S3 Presigned URL Exports

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -132,6 +132,15 @@ jobs:
             --s3-key "$DEPLOY_KEY" \
             --query 'FunctionName' --output text
 
+      - name: Deploy terra-exports
+        if: steps.changes.outputs.changed == 'true'
+        run: |
+          aws lambda update-function-code \
+            --function-name terra-exports \
+            --s3-bucket "${{ vars.ASSETS_BUCKET }}" \
+            --s3-key "$DEPLOY_KEY" \
+            --query 'FunctionName' --output text
+
       - name: Deploy terra-photo-processor
         if: steps.changes.outputs.changed == 'true'
         run: |

--- a/backend/deploy.sh
+++ b/backend/deploy.sh
@@ -34,6 +34,14 @@ aws lambda update-function-code \
   --query 'FunctionName' \
   --output text
 
+echo "Deploying terra-exports..."
+aws lambda update-function-code \
+  --function-name terra-exports \
+  --s3-bucket "$DEPLOY_BUCKET" \
+  --s3-key "$DEPLOY_KEY" \
+  --query 'FunctionName' \
+  --output text
+
 echo "Deploying terra-photo-processor..."
 aws lambda update-function-code \
   --function-name terra-photo-processor \

--- a/backend/src/handlers/api.py
+++ b/backend/src/handlers/api.py
@@ -90,15 +90,9 @@ def get_reports_coverage():
 def get_reports_export():
     params = app.current_event.query_string_parameters or {}
     try:
-        body, content_type, filename = export_reports(params)
+        return export_reports(params)
     except ValidationError as e:
         raise BadRequestError(_first_validation_message(e)) from e
-    return Response(
-        status_code=200,
-        content_type=content_type,
-        body=body,
-        headers={"Content-Disposition": f'attachment; filename="{filename}"'},
-    )
 
 
 @app.get("/crisis-events")

--- a/backend/src/handlers/exports.py
+++ b/backend/src/handlers/exports.py
@@ -1,9 +1,12 @@
 import csv
 import io
 import json
-from datetime import UTC, datetime
+import os
+import uuid
+from datetime import UTC, datetime, timedelta
 from typing import Literal
 
+import boto3
 from aws_lambda_powertools import Logger
 from pydantic import BaseModel, ConfigDict, Field
 
@@ -11,8 +14,11 @@ from src.handlers.reports import build_filter_clause
 from src.utils.db import get_connection
 
 logger = Logger()
+s3 = boto3.client("s3")
 
-EXPORT_ROW_CAP = 10000
+
+EXPORT_ROW_CEILING = 1_000_000 # Beyond 1M rows we'd want multipart streaming, out of scope here
+DOWNLOAD_URL_EXPIRY_SECONDS = 3600
 
 CSV_HEADER = [
     "id",
@@ -61,8 +67,8 @@ class ExportParams(BaseModel):
     building_id: str | None = Field(None, max_length=32)
 
 
-def export_reports(params: dict) -> tuple[str, str, str]:
-    """Return (body, content_type, filename) for the requested export."""
+def export_reports(params: dict) -> dict:
+    """Build the export, write it to S3, return a presigned download URL."""
     q = ExportParams(**params)
     where, values = build_filter_clause(q)
     # Flagged reports (#170) stay visible on the dashboard but are excluded
@@ -88,14 +94,44 @@ def export_reports(params: dict) -> tuple[str, str, str]:
             ORDER BY submitted_at DESC
             LIMIT %s
             """,
-            (*values, EXPORT_ROW_CAP),
+            (*values, EXPORT_ROW_CEILING),
         )
         rows = cur.fetchall()
 
     stamp = datetime.now(UTC).strftime("%Y%m%d-%H%M%S")
     if q.format == "csv":
-        return _to_csv(rows), "text/csv", f"terra-reports-{stamp}.csv"
-    return _to_geojson(rows), "application/geo+json", f"terra-reports-{stamp}.geojson"
+        body = _to_csv(rows)
+        content_type = "text/csv"
+        filename = f"terra-reports-{stamp}.csv"
+    else:
+        body = _to_geojson(rows)
+        content_type = "application/geo+json"
+        filename = f"terra-reports-{stamp}.geojson"
+
+    bucket = os.environ.get("EXPORTS_BUCKET", "")
+    key = f"exports/{uuid.uuid4()}/{filename}"
+    s3.put_object(
+        Bucket=bucket,
+        Key=key,
+        Body=body.encode("utf-8"),
+        ContentType=content_type,
+        ContentDisposition=f'attachment; filename="{filename}"',
+    )
+    download_url = s3.generate_presigned_url(
+        "get_object",
+        Params={"Bucket": bucket, "Key": key},
+        ExpiresIn=DOWNLOAD_URL_EXPIRY_SECONDS,
+    )
+    expires_at = (
+        datetime.now(UTC) + timedelta(seconds=DOWNLOAD_URL_EXPIRY_SECONDS)
+    ).isoformat()
+
+    return {
+        "download_url": download_url,
+        "expires_at": expires_at,
+        "total_rows": len(rows),
+        "filename": filename,
+    }
 
 
 def _to_csv(rows: list) -> str:

--- a/backend/tests/test_exports.py
+++ b/backend/tests/test_exports.py
@@ -5,7 +5,7 @@ from unittest.mock import MagicMock, patch
 import pytest
 from pydantic import ValidationError
 
-from src.handlers.exports import CSV_HEADER, export_reports
+from src.handlers.exports import CSV_HEADER, _to_csv, _to_geojson, export_reports
 
 
 def _row(**overrides):
@@ -56,61 +56,54 @@ def _mock_conn(rows):
 
 
 class TestExportReports:
+    @patch("src.handlers.exports.s3")
     @patch("src.handlers.exports.get_connection")
-    def test_geojson_format(self, mock_get_conn):
-        mock_get_conn.return_value, _ = _mock_conn([_row()])
+    def test_returns_presigned_download_url(self, mock_get_conn, mock_s3):
+        mock_get_conn.return_value, _ = _mock_conn([_row(), _row(id="report-2")])
+        mock_s3.generate_presigned_url.return_value = "https://example/exports/x.geojson?sig=abc"
 
-        body, content_type, filename = export_reports({"format": "geojson"})
+        result = export_reports({"format": "geojson"})
 
-        assert content_type == "application/geo+json"
-        assert filename.startswith("terra-reports-") and filename.endswith(".geojson")
-        parsed = json.loads(body)
-        assert parsed["type"] == "FeatureCollection"
-        assert len(parsed["features"]) == 1
-        feat = parsed["features"][0]
-        assert feat["geometry"]["coordinates"] == [0.5, 51.4]
-        assert feat["properties"]["damage_level"] == "partial"
-        assert feat["properties"]["photo_key"] == "uploads/abc.jpg"
-        assert "photo_url" not in feat["properties"]
-        assert "thumbnail_url" not in feat["properties"]
+        assert result["download_url"] == "https://example/exports/x.geojson?sig=abc"
+        assert result["total_rows"] == 2
+        assert result["filename"].startswith("terra-reports-")
+        assert result["filename"].endswith(".geojson")
+        assert "expires_at" in result
 
+    @patch("src.handlers.exports.s3")
     @patch("src.handlers.exports.get_connection")
-    def test_csv_format_header_and_row(self, mock_get_conn):
+    def test_uploads_geojson_body_to_s3(self, mock_get_conn, mock_s3):
         mock_get_conn.return_value, _ = _mock_conn([_row()])
+        mock_s3.generate_presigned_url.return_value = "https://example"
 
-        body, content_type, filename = export_reports({"format": "csv"})
+        export_reports({"format": "geojson"})
 
-        assert content_type == "text/csv"
-        assert filename.startswith("terra-reports-") and filename.endswith(".csv")
+        put = mock_s3.put_object.call_args.kwargs
+        assert put["ContentType"] == "application/geo+json"
+        assert put["Key"].startswith("exports/")
+        assert put["Key"].endswith(".geojson")
+        body = json.loads(put["Body"].decode("utf-8"))
+        assert body["type"] == "FeatureCollection"
+        assert body["features"][0]["properties"]["damage_level"] == "partial"
+        assert body["features"][0]["properties"]["photo_key"] == "uploads/abc.jpg"
+        assert "photo_url" not in body["features"][0]["properties"]
+
+    @patch("src.handlers.exports.s3")
+    @patch("src.handlers.exports.get_connection")
+    def test_uploads_csv_body_to_s3(self, mock_get_conn, mock_s3):
+        mock_get_conn.return_value, _ = _mock_conn([_row()])
+        mock_s3.generate_presigned_url.return_value = "https://example"
+
+        export_reports({"format": "csv"})
+
+        put = mock_s3.put_object.call_args.kwargs
+        assert put["ContentType"] == "text/csv"
+        assert put["Key"].endswith(".csv")
+        body = put["Body"].decode("utf-8")
         lines = body.strip().split("\r\n")
         assert lines[0].split(",") == CSV_HEADER
-        assert "photo_key" in CSV_HEADER
-        assert "photo_url" not in CSV_HEADER
         assert "uploads/abc.jpg" in lines[1]
         assert "partial" in lines[1]
-        assert "u10k7d2q" in lines[1]
-
-    @patch("src.handlers.exports.get_connection")
-    def test_csv_pipe_joins_list_fields(self, mock_get_conn):
-        mock_get_conn.return_value, _ = _mock_conn([
-            _row(crisis_nature=["Earthquake", "Flood"]),
-        ])
-
-        body, _, _ = export_reports({"format": "csv"})
-
-        assert "Earthquake|Flood" in body
-
-    @patch("src.handlers.exports.get_connection")
-    def test_csv_serialises_booleans_and_nulls(self, mock_get_conn):
-        mock_get_conn.return_value, _ = _mock_conn([
-            _row(debris_present=False, ai_confidence=None),
-        ])
-
-        body, _, _ = export_reports({"format": "csv"})
-        row = body.strip().split("\r\n")[1]
-        cells = row.split(",")
-        # debris_present is at index 10
-        assert cells[10] == "false"
 
     def test_unknown_format_rejected(self):
         with pytest.raises(ValidationError):
@@ -126,13 +119,47 @@ class TestExportReports:
             export_reports({"format": "csv", "h3": "DROP TABLE"})
         mock_get_conn.assert_not_called()
 
+    @patch("src.handlers.exports.s3")
     @patch("src.handlers.exports.get_connection")
-    def test_caps_to_export_row_cap(self, mock_get_conn):
+    def test_query_caps_at_ceiling(self, mock_get_conn, mock_s3):
         mock_conn, mock_cursor = _mock_conn([])
         mock_get_conn.return_value = mock_conn
+        mock_s3.generate_presigned_url.return_value = "x"
 
         export_reports({"format": "csv"})
 
         # LIMIT is the last bound param
         params = mock_cursor.execute.call_args[0][1]
-        assert params[-1] == 10000
+        assert params[-1] == 1_000_000
+
+    @patch("src.handlers.exports.s3")
+    @patch("src.handlers.exports.get_connection")
+    def test_excludes_flagged_reports(self, mock_get_conn, mock_s3):
+        mock_conn, mock_cursor = _mock_conn([])
+        mock_get_conn.return_value = mock_conn
+        mock_s3.generate_presigned_url.return_value = "x"
+
+        export_reports({"format": "csv"})
+
+        sql = mock_cursor.execute.call_args[0][0]
+        assert "flag_status IS NULL" in sql
+
+
+class TestSerializers:
+    def test_csv_pipe_joins_list_fields(self):
+        body = _to_csv([_row(crisis_nature=["Earthquake", "Flood"])])
+        assert "Earthquake|Flood" in body
+
+    def test_csv_serialises_booleans_and_nulls(self):
+        body = _to_csv([_row(debris_present=False, ai_confidence=None)])
+        row = body.strip().split("\r\n")[1]
+        cells = row.split(",")
+        # debris_present is at index 10
+        assert cells[10] == "false"
+
+    def test_geojson_strips_photo_url_and_thumbnail_url(self):
+        body = json.loads(_to_geojson([_row()]))
+        props = body["features"][0]["properties"]
+        assert "photo_url" not in props
+        assert "thumbnail_url" not in props
+        assert props["photo_key"] == "uploads/abc.jpg"

--- a/docs/api-reference.md
+++ b/docs/api-reference.md
@@ -120,7 +120,9 @@ The frontend treats every error as a silent drop and lets the user proceed witho
 
 ## GET /reports/export
 
-Download the filtered report set as a file. Accepts the same filter parameters as `GET /reports` plus a required `format` selector. The response includes a `Content-Disposition: attachment` header to trigger a browser download.
+Build the filtered report set as a file, upload it to S3, return a presigned download URL. Accepts the same filter parameters as `GET /reports` plus a required `format` selector.
+
+Flagged reports (`flag_status` set) are excluded.
 
 **Query Parameters**
 
@@ -133,16 +135,27 @@ Download the filtered report set as a file. Accepts the same filter parameters a
 | `infrastructure_type` | string | no | Pipe-separated infrastructure types |
 | `crisis_nature` | string | no | Pipe-separated crisis types |
 | `from` / `to` | string | no | ISO datetimes |
-| `building_id` | string | no | Single-building filter — returns every version, not just the latest |
+| `building_id` | string | no | Single-building filter, returns every version, not just the latest |
 
-The export caps at **10 000 rows** in v1. Larger result sets will be truncated; tighten filters or split by date range.
+**Response**
+
+```json
+{
+  "download_url": "https://terra-exports-*.s3.amazonaws.com/exports/<uuid>/terra-reports-20260613-153022.csv?X-Amz-...",
+  "expires_at": "2026-06-13T16:30:22+00:00",
+  "total_rows": 4327,
+  "filename": "terra-reports-20260613-153022.csv"
+}
+```
+
+Presigned URL is valid for 1 hour. The S3 object lives in the `terra-exports-...` bucket with a 7-day lifecycle expiration.
+
+Max 1,000,000 rows per export. Beyond that, multipart streaming would be required (out of scope for the demo).
 
 **Formats**
 
-- **CSV**: flat header row, list fields (`infrastructure_type`, `crisis_nature`, `pressing_needs`) joined with `|`, booleans as `true`/`false`. Photos are referenced by their stable `photo_key` (e.g. `uploads/<uuid>.jpg`); the thumbnail key follows the convention `thumbnails/<uuid>.jpg`. Look up photos via the dashboard for a fresh presigned URL.
-- **GeoJSON**: standard `FeatureCollection` (same feature shape as `GET /reports` but with `photo_key` in place of `photo_url`/`thumbnail_url`, and without the `total` field).
-
-GeoPackage and Shapefile are deferred — they require Fiona/GDAL in the Lambda zip; will follow up in Phase 3.
+- **CSV**: flat header row, list fields (`infrastructure_type`, `crisis_nature`, `pressing_needs`) joined with `|`, booleans as `true`/`false`. Photos are referenced by their stable `photo_key` (e.g. `uploads/<uuid>.jpg`); the thumbnail key follows the convention `thumbnails/<uuid>.jpg`.
+- **GeoJSON**: standard `FeatureCollection` (same feature shape as `GET /reports` but with `photo_key` in place of `photo_url` / `thumbnail_url`).
 
 ## GET /crisis-events
 

--- a/frontend/src/components/dashboard-sidebar.module.css
+++ b/frontend/src/components/dashboard-sidebar.module.css
@@ -321,10 +321,27 @@
   cursor: pointer;
 }
 
-.exportButton:hover {
+.exportButton:hover:not(:disabled) {
   background: var(--undpds-color-gray-100);
   border-color: var(--undpds-color-blue-600);
   color: var(--undpds-color-blue-600);
+}
+
+.exportButton:disabled {
+  background: var(--undpds-color-gray-100);
+  color: var(--undpds-color-gray-500);
+  border-color: var(--undpds-color-gray-300);
+  cursor: not-allowed;
+}
+
+.spinner {
+  animation: spin 1s linear infinite;
+}
+
+@keyframes spin {
+  to {
+    transform: rotate(360deg);
+  }
 }
 
 .detailsButton {

--- a/frontend/src/components/dashboard-sidebar.tsx
+++ b/frontend/src/components/dashboard-sidebar.tsx
@@ -1,5 +1,13 @@
-import { CircleCheck, TriangleAlert, CircleX, Download, X, PenLine } from "lucide-react";
-import type { ReactNode } from "react";
+import {
+  CircleCheck,
+  TriangleAlert,
+  CircleX,
+  Download,
+  Loader2,
+  X,
+  PenLine,
+} from "lucide-react";
+import { useState, type ReactNode } from "react";
 import { useAuth } from "react-oidc-context";
 import type { Filters, ReportFeature } from "../pages/dashboard";
 import { API_BASE } from "../utils/api";
@@ -7,26 +15,49 @@ import { MultiSelect } from "./multi-select";
 import styles from "./dashboard-sidebar.module.css";
 
 const CSV_HEADERS = [
-  "id", "building_id", "damage_level", "infrastructure_type", "crisis_nature",
-  "debris_present", "electricity_status", "health_status", "pressing_needs",
-  "infrastructure_description", "submitted_at", "latitude", "longitude",
-  "ai_damage_level", "ai_confidence", "version_chain_id",
+  "id",
+  "building_id",
+  "damage_level",
+  "infrastructure_type",
+  "crisis_nature",
+  "debris_present",
+  "electricity_status",
+  "health_status",
+  "pressing_needs",
+  "infrastructure_description",
+  "submitted_at",
+  "latitude",
+  "longitude",
+  "ai_damage_level",
+  "ai_confidence",
+  "version_chain_id",
 ];
 
 function toCSV(reports: ReportFeature[]): string {
-  const escape = (v: unknown) =>
-    `"${String(v ?? "").replace(/"/g, '""')}"`;
+  const escape = (v: unknown) => `"${String(v ?? "").replace(/"/g, '""')}"`;
   const rows = reports.map((r) => {
     const p = r.properties;
     const [lng, lat] = r.geometry.coordinates;
     return [
-      p.id, p.building_id ?? "", p.damage_level,
-      p.infrastructure_type.join("|"), p.crisis_nature.join("|"),
-      p.debris_present ?? "", p.electricity_status ?? "", p.health_status ?? "",
-      p.pressing_needs.join("|"), p.infrastructure_description ?? "",
-      p.submitted_at, lat, lng,
-      p.ai_damage_level ?? "", p.ai_confidence ?? "", p.version_chain_id,
-    ].map(escape).join(",");
+      p.id,
+      p.building_id ?? "",
+      p.damage_level,
+      p.infrastructure_type.join("|"),
+      p.crisis_nature.join("|"),
+      p.debris_present ?? "",
+      p.electricity_status ?? "",
+      p.health_status ?? "",
+      p.pressing_needs.join("|"),
+      p.infrastructure_description ?? "",
+      p.submitted_at,
+      lat,
+      lng,
+      p.ai_damage_level ?? "",
+      p.ai_confidence ?? "",
+      p.version_chain_id,
+    ]
+      .map(escape)
+      .join(",");
   });
   return [CSV_HEADERS.join(","), ...rows].join("\n");
 }
@@ -104,38 +135,35 @@ export const DashboardSidebar = ({
     filters.to !== "";
 
   const auth = useAuth();
+  const [exporting, setExporting] = useState<"csv" | "geojson" | null>(null);
 
   const downloadExport = async (format: "csv" | "geojson") => {
-    const params = new URLSearchParams({ format });
-    if (filters.damageLevel.length > 0)
-      params.set("damage_level", filters.damageLevel.join(","));
-    if (filters.infrastructureType.length > 0)
-      params.set("infrastructure_type", filters.infrastructureType.join("|"));
-    if (filters.crisisNature.length > 0)
-      params.set("crisis_nature", filters.crisisNature.join("|"));
-    if (filters.from) params.set("from", filters.from);
-    if (filters.to) params.set("to", filters.to);
+    if (exporting) return;
+    setExporting(format);
+    try {
+      const params = new URLSearchParams({ format });
+      if (filters.damageLevel.length > 0)
+        params.set("damage_level", filters.damageLevel.join(","));
+      if (filters.infrastructureType.length > 0)
+        params.set("infrastructure_type", filters.infrastructureType.join("|"));
+      if (filters.crisisNature.length > 0)
+        params.set("crisis_nature", filters.crisisNature.join("|"));
+      if (filters.from) params.set("from", filters.from);
+      if (filters.to) params.set("to", filters.to);
 
-    const token = auth.user?.access_token;
-    const res = await fetch(`${API_BASE}/reports/export?${params.toString()}`, {
-      headers: token ? { Authorization: `Bearer ${token}` } : {},
-    });
-    if (!res.ok) {
-      throw new Error(`Export failed: ${res.status}`);
+      const token = auth.user?.access_token;
+      const res = await fetch(
+        `${API_BASE}/reports/export?${params.toString()}`,
+        { headers: token ? { Authorization: `Bearer ${token}` } : {} },
+      );
+      if (!res.ok) {
+        throw new Error(`Export failed: ${res.status}`);
+      }
+      const { download_url } = (await res.json()) as { download_url: string };
+      window.location.href = download_url;
+    } finally {
+      setExporting(null);
     }
-    const blob = await res.blob();
-    const url = URL.createObjectURL(blob);
-    const filename =
-      res.headers
-        .get("Content-Disposition")
-        ?.match(/filename="?([^"]+)"?/)?.[1] ?? `terra-reports.${format}`;
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = filename;
-    document.body.appendChild(a);
-    a.click();
-    a.remove();
-    URL.revokeObjectURL(url);
   };
 
   return (
@@ -339,7 +367,10 @@ export const DashboardSidebar = ({
                     onClick={() =>
                       downloadBlob(
                         JSON.stringify(
-                          { type: "FeatureCollection", features: filteredReports },
+                          {
+                            type: "FeatureCollection",
+                            features: filteredReports,
+                          },
                           null,
                           2,
                         ),
@@ -358,17 +389,27 @@ export const DashboardSidebar = ({
                     type="button"
                     className={styles.exportButton}
                     onClick={() => downloadExport("csv")}
+                    disabled={exporting !== null}
                   >
-                    <Download size={14} />
-                    CSV
+                    {exporting === "csv" ? (
+                      <Loader2 size={14} className={styles.spinner} />
+                    ) : (
+                      <Download size={14} />
+                    )}
+                    {exporting === "csv" ? "Preparing..." : "CSV"}
                   </button>
                   <button
                     type="button"
                     className={styles.exportButton}
                     onClick={() => downloadExport("geojson")}
+                    disabled={exporting !== null}
                   >
-                    <Download size={14} />
-                    GeoJSON
+                    {exporting === "geojson" ? (
+                      <Loader2 size={14} className={styles.spinner} />
+                    ) : (
+                      <Download size={14} />
+                    )}
+                    {exporting === "geojson" ? "Preparing..." : "GeoJSON"}
                   </button>
                 </>
               )}

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -50,6 +50,15 @@ resource "aws_apigatewayv2_integration" "api" {
   payload_format_version = "2.0"
 }
 
+# Exports integration — separate Lambda with higher memory/timeout for
+# in-memory CSV/GeoJSON assembly before S3 upload.
+resource "aws_apigatewayv2_integration" "exports" {
+  api_id                 = aws_apigatewayv2_api.api.id
+  integration_type       = "AWS_PROXY"
+  integration_uri        = aws_lambda_function.exports.invoke_arn
+  payload_format_version = "2.0"
+}
+
 # Cognito JWT authorizer for analyst / admin routes.
 resource "aws_apigatewayv2_authorizer" "cognito" {
   api_id           = aws_apigatewayv2_api.api.id
@@ -122,7 +131,7 @@ resource "aws_apigatewayv2_route" "get_reports" {
 resource "aws_apigatewayv2_route" "get_reports_export" {
   api_id             = aws_apigatewayv2_api.api.id
   route_key          = "GET /reports/export"
-  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
+  target             = "integrations/${aws_apigatewayv2_integration.exports.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
 }
@@ -164,6 +173,14 @@ resource "aws_lambda_permission" "api_gateway" {
   statement_id  = "AllowAPIGateway"
   action        = "lambda:InvokeFunction"
   function_name = aws_lambda_function.api.function_name
+  principal     = "apigateway.amazonaws.com"
+  source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
+}
+
+resource "aws_lambda_permission" "api_gateway_exports" {
+  statement_id  = "AllowAPIGatewayExports"
+  action        = "lambda:InvokeFunction"
+  function_name = aws_lambda_function.exports.function_name
   principal     = "apigateway.amazonaws.com"
   source_arn    = "${aws_apigatewayv2_api.api.execution_arn}/*/*"
 }

--- a/infra/github_oidc.tf
+++ b/infra/github_oidc.tf
@@ -90,6 +90,7 @@ resource "aws_iam_role_policy" "github_actions_lambda" {
       ]
       Resource = [
         aws_lambda_function.api.arn,
+        aws_lambda_function.exports.arn,
         aws_lambda_function.photo_processor.arn,
       ]
     }]

--- a/infra/lambda.tf
+++ b/infra/lambda.tf
@@ -138,6 +138,39 @@ resource "aws_cloudwatch_log_group" "api" {
   retention_in_days = 14
 }
 
+resource "aws_lambda_function" "exports" {
+  function_name = "${var.project_name}-exports"
+  role          = aws_iam_role.lambda.arn
+  handler       = "src.handlers.api.handler"
+  runtime       = "python3.13"
+  timeout       = 60
+  memory_size   = 2048
+
+  filename         = data.archive_file.lambda_placeholder.output_path
+  source_code_hash = data.archive_file.lambda_placeholder.output_base64sha256
+
+  layers = [local.powertools_layer_arn]
+
+  environment {
+    variables = {
+      POWERTOOLS_SERVICE_NAME          = "${var.project_name}-exports"
+      POWERTOOLS_PARAMETERS_SSM_PREFIX = "/${var.project_name}"
+      LOG_LEVEL                        = "INFO"
+      EXPORTS_BUCKET                   = aws_s3_bucket.exports.id
+      PHOTOS_BUCKET                    = aws_s3_bucket.photos.id
+    }
+  }
+
+  lifecycle {
+    ignore_changes = [filename, source_code_hash]
+  }
+}
+
+resource "aws_cloudwatch_log_group" "exports" {
+  name              = "/aws/lambda/${aws_lambda_function.exports.function_name}"
+  retention_in_days = 14
+}
+
 # Photo processing Lambda (S3 trigger for EXIF stripping, thumbnails)
 resource "aws_lambda_function" "photo_processor" {
   function_name = "${var.project_name}-photo-processor"


### PR DESCRIPTION
closes #238 

 - Add new export lambda that sends files via presigned S3 download URL
 - Remove 10k row truncation
 - Add spinner + disabled state for export buttons while request is in-flight
 - Update docs