### PR TITLE
feat: analyst priority flag — direct crowd to specific buildings (#235)

### DIFF
--- a/backend/src/handlers/api.py
+++ b/backend/src/handlers/api.py
@@ -20,7 +20,14 @@ from src.handlers.crisis_events import (
 )
 from src.handlers.exports import export_reports
 from src.handlers.photos import get_upload_url
-from src.handlers.reports import create_report, query_coverage, query_reports, review_report
+from src.handlers.reports import (
+    create_report,
+    get_priority_buildings,
+    query_coverage,
+    query_reports,
+    review_report,
+    set_building_priority,
+)
 
 logger = Logger()
 tracer = Tracer()
@@ -158,6 +165,22 @@ def post_report():
         return create_report(body)
     except ValidationError as e:
         raise BadRequestError(_first_validation_message(e)) from e
+
+
+@app.get("/buildings/priority")
+@tracer.capture_method
+def get_buildings_priority():
+    return get_priority_buildings()
+
+
+@app.patch("/buildings/<building_id>/priority")
+@tracer.capture_method
+def patch_building_priority(building_id: str):
+    body = app.current_event.json_body if app.current_event.body else {}
+    try:
+        return set_building_priority(building_id, bool(body.get("flagged", True)))
+    except ValueError as e:
+        raise BadRequestError(str(e)) from e
 
 
 @app.patch("/reports/<report_id>/review")

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -354,8 +354,10 @@ def query_reports(params: dict) -> dict:
                  WHERE r2.version_chain_id = reports.version_chain_id) as version_count,
                 follow_up_responses,
                 damage_level, analyst_damage_level, flag_status, flag_reason,
-                infrastructure_description_en, priority_flag
+                infrastructure_description_en,
+                (pb.building_id IS NOT NULL) AS priority_flag
             FROM reports
+            LEFT JOIN priority_buildings pb ON reports.building_id = pb.building_id
             WHERE {where}
             ORDER BY submitted_at DESC
             LIMIT %s OFFSET %s
@@ -432,9 +434,10 @@ def query_coverage(params: dict) -> dict:
             f"""
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
-                building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
-                submitted_at, priority_flag
+                reports.building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
+                submitted_at, (pb.building_id IS NOT NULL) AS priority_flag
             FROM reports
+            LEFT JOIN priority_buildings pb ON reports.building_id = pb.building_id
             WHERE {where}
             ORDER BY submitted_at DESC
             LIMIT %s OFFSET %s
@@ -517,16 +520,9 @@ def review_report(report_id: str, body: dict) -> dict:
         updates.append("flag_reason = %s")
         values.append(reason)
 
-    if "priority_flag" in body:
-        pf = body["priority_flag"]
-        if not isinstance(pf, bool):
-            raise ValueError("priority_flag must be a boolean")
-        updates.append("priority_flag = %s")
-        values.append(pf)
-
     if not updates:
         raise ValueError(
-            "Provide at least one of: analyst_damage_level, flag_status, flag_reason, priority_flag"
+            "Provide at least one of: analyst_damage_level, flag_status, flag_reason"
         )
 
     conn = get_connection()
@@ -537,7 +533,7 @@ def review_report(report_id: str, body: dict) -> dict:
             SET {", ".join(updates)}, updated_at = now()
             WHERE id = %s
             RETURNING id, COALESCE(analyst_damage_level, damage_level),
-                      damage_level, analyst_damage_level, flag_status, flag_reason, priority_flag
+                      damage_level, analyst_damage_level, flag_status, flag_reason
             """,
             (*values, report_id),
         )
@@ -553,7 +549,6 @@ def review_report(report_id: str, body: dict) -> dict:
         "analyst_damage_level": row[3],
         "flag_status": row[4],
         "flag_reason": row[5],
-        "priority_flag": row[6],
     }
 
 
@@ -581,3 +576,36 @@ def _find_version_chain(building_id: str | None, h3_r12: str) -> uuid.UUID:
 
     # New chain
     return uuid.uuid4()
+
+
+def get_priority_buildings() -> dict:
+    """Return all building IDs currently flagged for more photos."""
+    conn = get_connection()
+    with conn.cursor() as cur:
+        cur.execute("SELECT building_id FROM priority_buildings ORDER BY flagged_at DESC")
+        rows = cur.fetchall()
+    return {"building_ids": [row[0] for row in rows]}
+
+
+def set_building_priority(building_id: str, flagged: bool) -> dict:
+    """Upsert or delete a building from priority_buildings."""
+    if not building_id or len(building_id) > 64:
+        raise ValueError("building_id must be 1–64 characters")
+    conn = get_connection()
+    with conn.cursor() as cur:
+        if flagged:
+            cur.execute(
+                """
+                INSERT INTO priority_buildings (building_id)
+                VALUES (%s)
+                ON CONFLICT (building_id) DO NOTHING
+                """,
+                (building_id,),
+            )
+        else:
+            cur.execute(
+                "DELETE FROM priority_buildings WHERE building_id = %s",
+                (building_id,),
+            )
+    conn.commit()
+    return {"building_id": building_id, "priority_flag": flagged}

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -354,7 +354,7 @@ def query_reports(params: dict) -> dict:
                  WHERE r2.version_chain_id = reports.version_chain_id) as version_count,
                 follow_up_responses,
                 damage_level, analyst_damage_level, flag_status, flag_reason,
-                infrastructure_description_en
+                infrastructure_description_en, priority_flag
             FROM reports
             WHERE {where}
             ORDER BY submitted_at DESC
@@ -406,6 +406,7 @@ def query_reports(params: dict) -> dict:
                 "flag_status": row[26],
                 "flag_reason": row[27],
                 "infrastructure_description_en": row[28],
+                "priority_flag": row[29],
             },
         })
 
@@ -432,7 +433,7 @@ def query_coverage(params: dict) -> dict:
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
                 building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
-                submitted_at
+                submitted_at, priority_flag
             FROM reports
             WHERE {where}
             ORDER BY submitted_at DESC
@@ -457,6 +458,7 @@ def query_coverage(params: dict) -> dict:
                 "building_id": row[3],
                 "damage_level": row[4],
                 "submitted_at": row[5].isoformat() if row[5] else None,
+                "priority_flag": row[6],
             },
         }
         for row in rows
@@ -515,9 +517,16 @@ def review_report(report_id: str, body: dict) -> dict:
         updates.append("flag_reason = %s")
         values.append(reason)
 
+    if "priority_flag" in body:
+        pf = body["priority_flag"]
+        if not isinstance(pf, bool):
+            raise ValueError("priority_flag must be a boolean")
+        updates.append("priority_flag = %s")
+        values.append(pf)
+
     if not updates:
         raise ValueError(
-            "Provide at least one of: analyst_damage_level, flag_status, flag_reason"
+            "Provide at least one of: analyst_damage_level, flag_status, flag_reason, priority_flag"
         )
 
     conn = get_connection()
@@ -528,7 +537,7 @@ def review_report(report_id: str, body: dict) -> dict:
             SET {", ".join(updates)}, updated_at = now()
             WHERE id = %s
             RETURNING id, COALESCE(analyst_damage_level, damage_level),
-                      damage_level, analyst_damage_level, flag_status, flag_reason
+                      damage_level, analyst_damage_level, flag_status, flag_reason, priority_flag
             """,
             (*values, report_id),
         )
@@ -544,6 +553,7 @@ def review_report(report_id: str, body: dict) -> dict:
         "analyst_damage_level": row[3],
         "flag_status": row[4],
         "flag_reason": row[5],
+        "priority_flag": row[6],
     }
 
 

--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -322,7 +322,7 @@ def build_filter_clause(q: "ReportsQueryParams | object") -> tuple[str, list]:
     # When querying by building_id, show all versions not just latest
     if q.building_id:
         conditions = [c for c in conditions if c != "is_latest = true"]
-        conditions.append("building_id = %s")
+        conditions.append("reports.building_id = %s")
         values.append(q.building_id)
 
     return " AND ".join(conditions), values
@@ -342,7 +342,7 @@ def query_reports(params: dict) -> dict:
             f"""
             SELECT
                 id, ST_X(location) as lng, ST_Y(location) as lat,
-                building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
+                reports.building_id, COALESCE(analyst_damage_level, damage_level) as damage_level,
                 ai_damage_level, ai_infrastructure_type, ai_confidence,
                 photo_url, thumbnail_url,
                 infrastructure_type, infrastructure_description,

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -176,6 +176,7 @@ class TestQueryReports:
                 None,  # follow_up_responses
                 "partial", None, None, None,  # community_damage_level, analyst_damage_level, flag_status, flag_reason
                 None,  # infrastructure_description_en
+                False,  # priority_flag
             )
         ]
         mock_cursor.fetchone.return_value = (1,)
@@ -425,7 +426,7 @@ class TestQueryCoverage:
         from datetime import datetime, timezone
         mock_conn = MagicMock()
         mock_cursor = MagicMock()
-        # SELECT id, lng, lat, building_id, damage_level, submitted_at
+        # SELECT id, lng, lat, building_id, damage_level, submitted_at, priority_flag
         mock_cursor.fetchall.return_value = [
             (
                 "report-id-1",
@@ -434,6 +435,7 @@ class TestQueryCoverage:
                 "u10k7d2q",
                 "partial",
                 datetime(2026, 4, 17, tzinfo=timezone.utc),
+                False,  # priority_flag
             )
         ]
         mock_cursor.fetchone.return_value = (1,)
@@ -464,6 +466,7 @@ class TestQueryCoverage:
             (
                 "report-id-1", 36.16, 36.2, "u10k7d2q", "partial",
                 datetime(2026, 4, 17, tzinfo=timezone.utc),
+                False,  # priority_flag
             )
         ]
         mock_cursor.fetchone.return_value = (1,)

--- a/db/001_initial_schema.sql
+++ b/db/001_initial_schema.sql
@@ -81,6 +81,13 @@ CREATE TABLE public.crisis_events (
 );
 
 
+-- Analyst priority flag: request more photos for specific buildings
+CREATE TABLE public.priority_buildings (
+    building_id text NOT NULL,
+    flagged_at timestamp with time zone DEFAULT now() NOT NULL
+);
+
+
 CREATE TABLE public.reports (
     id uuid DEFAULT gen_random_uuid() NOT NULL,
     crisis_event_id uuid,
@@ -137,6 +144,10 @@ ALTER TABLE ONLY public.building_footprints
 
 ALTER TABLE ONLY public.crisis_events
     ADD CONSTRAINT crisis_events_pkey PRIMARY KEY (id);
+
+
+ALTER TABLE ONLY public.priority_buildings
+    ADD CONSTRAINT priority_buildings_pkey PRIMARY KEY (building_id);
 
 
 ALTER TABLE ONLY public.reports

--- a/db/011_priority_flag.sql
+++ b/db/011_priority_flag.sql
@@ -1,0 +1,6 @@
+-- Analyst priority flag: request more photos for specific buildings (#235)
+-- Analyst sets priority_flag = true on a report; the community map highlights
+-- that building with an amber outline to direct crowd coverage.
+ALTER TABLE reports ADD COLUMN priority_flag BOOLEAN NOT NULL DEFAULT false;
+
+CREATE INDEX idx_reports_priority_flag ON reports (building_id) WHERE priority_flag = true;

--- a/db/011_priority_flag.sql
+++ b/db/011_priority_flag.sql
@@ -1,7 +1,0 @@
--- Analyst priority flag: request more photos for specific buildings (#235)
--- Separate table so any building can be flagged regardless of whether it has
--- a report yet — analyst directs the crowd to unassessed buildings too.
-CREATE TABLE priority_buildings (
-    building_id TEXT PRIMARY KEY,
-    flagged_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
-);

--- a/db/011_priority_flag.sql
+++ b/db/011_priority_flag.sql
@@ -1,6 +1,7 @@
 -- Analyst priority flag: request more photos for specific buildings (#235)
--- Analyst sets priority_flag = true on a report; the community map highlights
--- that building with an amber outline to direct crowd coverage.
-ALTER TABLE reports ADD COLUMN priority_flag BOOLEAN NOT NULL DEFAULT false;
-
-CREATE INDEX idx_reports_priority_flag ON reports (building_id) WHERE priority_flag = true;
+-- Separate table so any building can be flagged regardless of whether it has
+-- a report yet — analyst directs the crowd to unassessed buildings too.
+CREATE TABLE priority_buildings (
+    building_id TEXT PRIMARY KEY,
+    flagged_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/frontend/src/components/dashboard-map.tsx
+++ b/frontend/src/components/dashboard-map.tsx
@@ -49,6 +49,8 @@ export const DashboardMap = ({
   const tooltipRef = useRef<HTMLDivElement>(null);
   const onReportSelectRef = useRef(onReportSelect);
   const reportsByIdRef = useRef<Map<string, ReportFeature>>(new Map());
+  const apiRef = useRef(api);
+  const priorityBuildingsRef = useRef<Set<string>>(new Set());
   const hasFittedRef = useRef(false);
   const mapLoadedRef = useRef(false);
   const [mapMode, setMapMode] = useState<MapMode>("clusters");
@@ -75,6 +77,10 @@ export const DashboardMap = ({
   useEffect(() => {
     onReportSelectRef.current = onReportSelect;
   }, [onReportSelect]);
+
+  useEffect(() => {
+    apiRef.current = api;
+  }, [api]);
 
   useEffect(() => {
     onPolygonFilterRef.current = onPolygonFilter;
@@ -121,6 +127,7 @@ export const DashboardMap = ({
           buildings: {
             type: "vector",
             url: `pmtiles://${VIDA_BUILDINGS_URL}`,
+            promoteId: { goog_msft_osm_building_footprints: "geohash" },
           },
         },
         layers: [
@@ -206,6 +213,25 @@ export const DashboardMap = ({
           "text-color": "#1e3a8a",
           "text-halo-color": "#ffffff",
           "text-halo-width": 2,
+        },
+      });
+
+      // Amber dashed outline for buildings the analyst has flagged for more photos (#235).
+      map.addLayer({
+        id: "building-priority-outline",
+        type: "line",
+        source: "buildings",
+        "source-layer": "goog_msft_osm_building_footprints",
+        minzoom: 14,
+        paint: {
+          "line-color": "#f59e0b",
+          "line-width": [
+            "case",
+            ["boolean", ["feature-state", "priority_flag"], false],
+            3,
+            0,
+          ],
+          "line-dasharray": [2, 1],
         },
       });
 
@@ -459,6 +485,46 @@ export const DashboardMap = ({
         }
       });
 
+      // Click unassessed building footprint to toggle priority flag.
+      // Skips when draw mode is active or when a report marker sits at the same point.
+      map.on("click", "building-footprints", (e) => {
+        if (drawModeRef.current !== "idle") return;
+        const reportFeatures = map.queryRenderedFeatures(e.point, { layers: ["report-markers"] });
+        if (reportFeatures.length > 0) return;
+        const feature = e.features?.[0];
+        const bid = feature?.properties?.geohash as string | undefined;
+        if (!bid) return;
+
+        const currentlyFlagged = priorityBuildingsRef.current.has(bid);
+        const newFlagged = !currentlyFlagged;
+        if (newFlagged) priorityBuildingsRef.current.add(bid);
+        else priorityBuildingsRef.current.delete(bid);
+        map.setFeatureState(
+          { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
+          { priority_flag: newFlagged },
+        );
+        apiRef.current(`/buildings/${bid}/priority`, {
+          method: "PATCH",
+          body: JSON.stringify({ flagged: newFlagged }),
+        }).catch(() => {
+          // Rollback optimistic update on failure
+          if (newFlagged) priorityBuildingsRef.current.delete(bid);
+          else priorityBuildingsRef.current.add(bid);
+          map.setFeatureState(
+            { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
+            { priority_flag: !newFlagged },
+          );
+        });
+      });
+
+      map.on("mouseenter", "building-footprints", () => {
+        if (drawModeRef.current !== "idle") return;
+        map.getCanvas().style.cursor = "pointer";
+      });
+      map.on("mouseleave", "building-footprints", () => {
+        map.getCanvas().style.cursor = "";
+      });
+
       // Pointer cursors + hover tooltips
       map.on("mouseenter", "clusters", (e) => {
         if (drawModeRef.current === "drawing") return;
@@ -621,6 +687,38 @@ export const DashboardMap = ({
     return () => {
       cancelled = true;
     };
+  }, [api]);
+
+  // Fetch priority buildings and apply feature-state so the amber outline appears.
+  useEffect(() => {
+    const map = mapRef.current;
+    if (!map) return;
+    let cancelled = false;
+
+    const applyPriority = (buildingIds: string[]) => {
+      priorityBuildingsRef.current = new Set(buildingIds);
+      for (const bid of buildingIds) {
+        map.setFeatureState(
+          { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
+          { priority_flag: true },
+        );
+      }
+    };
+
+    const fetchAndApply = async () => {
+      try {
+        const result = await api("/buildings/priority");
+        if (cancelled) return;
+        applyPriority(result.building_ids ?? []);
+      } catch {
+        // best-effort
+      }
+    };
+
+    if (map.isStyleLoaded()) fetchAndApply();
+    else map.once("load", fetchAndApply);
+
+    return () => { cancelled = true; };
   }, [api]);
 
   useEffect(() => {

--- a/frontend/src/components/dashboard-map.tsx
+++ b/frontend/src/components/dashboard-map.tsx
@@ -485,7 +485,7 @@ export const DashboardMap = ({
         }
       });
 
-      // Click unassessed building footprint to toggle priority flag.
+      // Click unassessed building footprint to show a confirmation popup.
       // Skips when draw mode is active or when a report marker sits at the same point.
       map.on("click", "building-footprints", (e) => {
         if (drawModeRef.current !== "idle") return;
@@ -496,24 +496,40 @@ export const DashboardMap = ({
         if (!bid) return;
 
         const currentlyFlagged = priorityBuildingsRef.current.has(bid);
-        const newFlagged = !currentlyFlagged;
-        if (newFlagged) priorityBuildingsRef.current.add(bid);
-        else priorityBuildingsRef.current.delete(bid);
-        map.setFeatureState(
-          { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
-          { priority_flag: newFlagged },
-        );
-        apiRef.current(`/buildings/${bid}/priority`, {
-          method: "PATCH",
-          body: JSON.stringify({ flagged: newFlagged }),
-        }).catch(() => {
-          // Rollback optimistic update on failure
-          if (newFlagged) priorityBuildingsRef.current.delete(bid);
-          else priorityBuildingsRef.current.add(bid);
+        const heading = currentlyFlagged ? "Priority flagged" : "Tag building as priority?";
+        const btnLabel = currentlyFlagged ? "Remove flag" : "Flag for photos";
+        const btnColor = currentlyFlagged ? "#6b7280" : "#0469a5";
+
+        const popup = new maplibregl.Popup({ offset: 10, closeButton: true, maxWidth: "200px" })
+          .setLngLat(e.lngLat)
+          .setHTML(
+            `<div class="${styles.popup}" style="padding:4px 2px">` +
+              `<div style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.03em;margin-bottom:8px">${escapeHtml(heading)}</div>` +
+              `<button type="button" style="width:100%;padding:5px 10px;font-size:0.75rem;font-weight:600;background:${btnColor};color:#fff;border:none;cursor:pointer">${escapeHtml(btnLabel)}</button>` +
+            `</div>`,
+          )
+          .addTo(map);
+
+        popup.getElement().querySelector("button")?.addEventListener("click", () => {
+          popup.remove();
+          const newFlagged = !currentlyFlagged;
+          if (newFlagged) priorityBuildingsRef.current.add(bid);
+          else priorityBuildingsRef.current.delete(bid);
           map.setFeatureState(
             { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
-            { priority_flag: !newFlagged },
+            { priority_flag: newFlagged },
           );
+          apiRef.current(`/buildings/${bid}/priority`, {
+            method: "PATCH",
+            body: JSON.stringify({ flagged: newFlagged }),
+          }).catch(() => {
+            if (newFlagged) priorityBuildingsRef.current.delete(bid);
+            else priorityBuildingsRef.current.add(bid);
+            map.setFeatureState(
+              { source: "buildings", sourceLayer: "goog_msft_osm_building_footprints", id: bid },
+              { priority_flag: !newFlagged },
+            );
+          });
         });
       });
 

--- a/frontend/src/components/dashboard-map.tsx
+++ b/frontend/src/components/dashboard-map.tsx
@@ -216,7 +216,7 @@ export const DashboardMap = ({
         },
       });
 
-      // Amber dashed outline for buildings the analyst has flagged for more photos (#235).
+      // Purple dashed outline for buildings the analyst has flagged for more photos (#235).
       map.addLayer({
         id: "building-priority-outline",
         type: "line",
@@ -224,7 +224,7 @@ export const DashboardMap = ({
         "source-layer": "goog_msft_osm_building_footprints",
         minzoom: 14,
         paint: {
-          "line-color": "#f59e0b",
+          "line-color": "#7c3aed",
           "line-width": [
             "case",
             ["boolean", ["feature-state", "priority_flag"], false],

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -134,7 +134,7 @@ export const Map = ({
     map.on("load", () => {
       // Damage-level fill driven by feature-state set from /reports bbox fetch.
       // minzoom 16: buildings are too small to read fills at lower zoom.
-      // Outline is left at default for now — reserved for analyst priority flag (#46).
+      // Outline left at default — priority-flag amber border handled by building-priority-outline layer (#235).
       map.addLayer({
         id: "building-damage",
         type: "fill",
@@ -153,6 +153,27 @@ export const Map = ({
             "transparent",
           ],
           "fill-opacity": 0.7,
+        },
+      });
+
+      // Amber dashed outline for buildings the analyst has flagged as needing
+      // more photos (#235). Line width is 0 for unflagged buildings so the
+      // layer is effectively invisible without a separate filter.
+      map.addLayer({
+        id: "building-priority-outline",
+        type: "line",
+        source: "buildings",
+        "source-layer": BUILDINGS_SOURCE_LAYER,
+        minzoom: 16,
+        paint: {
+          "line-color": "#f59e0b",
+          "line-width": [
+            "case",
+            ["boolean", ["feature-state", "priority_flag"], false],
+            3,
+            0,
+          ],
+          "line-dasharray": [2, 1],
         },
       });
 
@@ -292,7 +313,7 @@ export const Map = ({
               sourceLayer: BUILDINGS_SOURCE_LAYER,
               id: bid,
             },
-            { damage_level: dl },
+            { damage_level: dl, priority_flag: f.properties?.priority_flag ?? false },
           );
         }
         setCoverageCount((prev) => ({

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -61,6 +61,9 @@ export const Map = ({
   const gpsPositionRef = useRef<[number, number] | null>(null);
   const onBuildingSelectRef = useRef(onBuildingSelect);
   const onManualPinRef = useRef(onManualPin);
+  const priorityBuildingIdsRef = useRef<Set<string>>(new Set());
+  const priorityHeadingRef = useRef(t("location.priorityHeading"));
+  const prioritySubmitRef = useRef(t("common.submit"));
   const [coverageCount, setCoverageCount] = useState<{
     assessed: number;
     total: number;
@@ -73,6 +76,11 @@ export const Map = ({
   useEffect(() => {
     onManualPinRef.current = onManualPin;
   }, [onManualPin]);
+
+  useEffect(() => {
+    priorityHeadingRef.current = t("location.priorityHeading");
+    prioritySubmitRef.current = t("common.submit");
+  }, [t]);
 
   useEffect(() => {
     if (!containerRef.current || mapRef.current) return;
@@ -156,7 +164,7 @@ export const Map = ({
         },
       });
 
-      // Amber dashed outline for buildings the analyst has flagged as needing
+      // Purple dashed outline for buildings the analyst has flagged as needing
       // more photos (#235). Line width is 0 for unflagged buildings so the
       // layer is effectively invisible without a separate filter.
       map.addLayer({
@@ -166,7 +174,7 @@ export const Map = ({
         "source-layer": BUILDINGS_SOURCE_LAYER,
         minzoom: 16,
         paint: {
-          "line-color": "#f59e0b",
+          "line-color": "#7c3aed",
           "line-width": [
             "case",
             ["boolean", ["feature-state", "priority_flag"], false],
@@ -228,13 +236,31 @@ export const Map = ({
         features: [{ type: "Feature", geometry, properties: {} }],
       });
 
-      onBuildingSelectRef.current?.({
+      const buildingData = {
         buildingId: props.geohash,
         center,
         areaM2: props.area_in_meters ?? 0,
         source: props.bf_source ?? "",
         geometry,
-      });
+      };
+
+      if (priorityBuildingIdsRef.current.has(props.geohash)) {
+        const popup = new maplibregl.Popup({ offset: 10, closeButton: true, maxWidth: "220px" })
+          .setLngLat(e.lngLat)
+          .setHTML(
+            `<div style="padding:4px 2px">` +
+              `<div style="font-size:0.75rem;font-weight:700;text-transform:uppercase;letter-spacing:.03em;margin-bottom:8px">${priorityHeadingRef.current}</div>` +
+              `<button type="button" style="width:100%;padding:5px 10px;font-size:0.75rem;font-weight:600;background:#7c3aed;color:#fff;border:none;cursor:pointer;border-radius:2px">${prioritySubmitRef.current}</button>` +
+            `</div>`,
+          )
+          .addTo(map);
+        popup.getElement().querySelector("button")?.addEventListener("click", () => {
+          popup.remove();
+          onBuildingSelectRef.current?.(buildingData);
+        });
+      } else {
+        onBuildingSelectRef.current?.(buildingData);
+      }
     });
 
     // Drop a manual pin when clicking off any building — covers no-GPS and
@@ -317,6 +343,7 @@ export const Map = ({
           );
         }
         // Apply priority flag to unassessed buildings not covered above
+        priorityBuildingIdsRef.current = new Set(priorityIds);
         for (const bid of priorityIds) {
           if (seen.has(bid)) continue;
           map.setFeatureState(

--- a/frontend/src/components/map.tsx
+++ b/frontend/src/components/map.tsx
@@ -291,16 +291,20 @@ export const Map = ({
       map.getCanvas().style.cursor = "";
     });
 
-    // Fetch reported buildings in the current viewport and apply feature-state
-    // so the damage-level fill layer colours the correct polygons.
+    // Fetch reported buildings + priority flags and apply feature-state.
+    // Two parallel requests: coverage (viewport bbox) for assessed buildings,
+    // and the full priority list for unassessed buildings the analyst has flagged.
     const fetchNearbyReports = async () => {
       if (map.getZoom() < 14) return;
       const b = map.getBounds();
       try {
-        const result = await api(
-          `/reports/coverage?west=${b.getWest()}&south=${b.getSouth()}&east=${b.getEast()}&north=${b.getNorth()}&limit=500`,
-        );
-        const features: ReportFeature[] = result?.features ?? [];
+        const [coverageResult, priorityResult] = await Promise.all([
+          api(`/reports/coverage?west=${b.getWest()}&south=${b.getSouth()}&east=${b.getEast()}&north=${b.getNorth()}&limit=500`),
+          api("/buildings/priority"),
+        ]);
+        const features: ReportFeature[] = coverageResult?.features ?? [];
+        const priorityIds: string[] = priorityResult?.building_ids ?? [];
+
         const seen = new Set<string>();
         for (const f of features) {
           const bid = f.properties?.building_id;
@@ -308,12 +312,16 @@ export const Map = ({
           if (!bid || !dl || seen.has(bid)) continue;
           seen.add(bid);
           map.setFeatureState(
-            {
-              source: "buildings",
-              sourceLayer: BUILDINGS_SOURCE_LAYER,
-              id: bid,
-            },
+            { source: "buildings", sourceLayer: BUILDINGS_SOURCE_LAYER, id: bid },
             { damage_level: dl, priority_flag: f.properties?.priority_flag ?? false },
+          );
+        }
+        // Apply priority flag to unassessed buildings not covered above
+        for (const bid of priorityIds) {
+          if (seen.has(bid)) continue;
+          map.setFeatureState(
+            { source: "buildings", sourceLayer: BUILDINGS_SOURCE_LAYER, id: bid },
+            { priority_flag: true },
           );
         }
         setCoverageCount((prev) => ({

--- a/frontend/src/components/report-details-modal.tsx
+++ b/frontend/src/components/report-details-modal.tsx
@@ -24,7 +24,7 @@ export const ReportDetailsModal = ({
   const [showOriginalDesc, setShowOriginalDesc] = useState(false);
   const api = useApi();
 
-  const sendReview = async (patch: Record<string, string | null>) => {
+  const sendReview = async (patch: Record<string, string | boolean | null>) => {
     setSaving(true);
     setReviewError(null);
     try {
@@ -41,6 +41,7 @@ export const ReportDetailsModal = ({
           analyst_damage_level: result.analyst_damage_level,
           flag_status: result.flag_status,
           flag_reason: result.flag_reason,
+          priority_flag: result.priority_flag,
         },
       });
     } catch (err) {
@@ -185,6 +186,20 @@ export const ReportDetailsModal = ({
                 </button>
               </div>
             )}
+
+            <div className={styles.reviewRow}>
+              <span className={styles.reviewLabel}>Photo request</span>
+              <div className={styles.reviewButtons}>
+                <button
+                  type="button"
+                  disabled={saving}
+                  className={`${styles.reviewBtn} ${p.priority_flag ? styles.reviewBtnActive : ""}`}
+                  onClick={() => sendReview({ priority_flag: !p.priority_flag })}
+                >
+                  {p.priority_flag ? "Requested" : "Request photo"}
+                </button>
+              </div>
+            </div>
 
             <div className={styles.reviewRow}>
               <span className={styles.reviewLabel}>Flag</span>

--- a/frontend/src/components/report-details-modal.tsx
+++ b/frontend/src/components/report-details-modal.tsx
@@ -22,9 +22,10 @@ export const ReportDetailsModal = ({
   const [saving, setSaving] = useState(false);
   const [reviewError, setReviewError] = useState<string | null>(null);
   const [showOriginalDesc, setShowOriginalDesc] = useState(false);
+  const [priorityFlag, setPriorityFlag] = useState(p.priority_flag ?? false);
   const api = useApi();
 
-  const sendReview = async (patch: Record<string, string | boolean | null>) => {
+  const sendReview = async (patch: Record<string, string | null>) => {
     setSaving(true);
     setReviewError(null);
     try {
@@ -41,12 +42,30 @@ export const ReportDetailsModal = ({
           analyst_damage_level: result.analyst_damage_level,
           flag_status: result.flag_status,
           flag_reason: result.flag_reason,
-          priority_flag: result.priority_flag,
         },
       });
     } catch (err) {
       setReviewError(
         err instanceof Error ? err.message : "Failed to save review",
+      );
+    } finally {
+      setSaving(false);
+    }
+  };
+
+  const togglePriority = async () => {
+    if (!p.building_id) return;
+    setSaving(true);
+    setReviewError(null);
+    try {
+      await api(`/buildings/${p.building_id}/priority`, {
+        method: "PATCH",
+        body: JSON.stringify({ flagged: !priorityFlag }),
+      });
+      setPriorityFlag(!priorityFlag);
+    } catch (err) {
+      setReviewError(
+        err instanceof Error ? err.message : "Failed to save",
       );
     } finally {
       setSaving(false);
@@ -187,19 +206,21 @@ export const ReportDetailsModal = ({
               </div>
             )}
 
-            <div className={styles.reviewRow}>
-              <span className={styles.reviewLabel}>Photo request</span>
-              <div className={styles.reviewButtons}>
-                <button
-                  type="button"
-                  disabled={saving}
-                  className={`${styles.reviewBtn} ${p.priority_flag ? styles.reviewBtnActive : ""}`}
-                  onClick={() => sendReview({ priority_flag: !p.priority_flag })}
-                >
-                  {p.priority_flag ? "Requested" : "Request photo"}
-                </button>
+            {p.building_id && (
+              <div className={styles.reviewRow}>
+                <span className={styles.reviewLabel}>Photo request</span>
+                <div className={styles.reviewButtons}>
+                  <button
+                    type="button"
+                    disabled={saving}
+                    className={`${styles.reviewBtn} ${priorityFlag ? styles.reviewBtnActive : ""}`}
+                    onClick={togglePriority}
+                  >
+                    {priorityFlag ? "Requested" : "Request photo"}
+                  </button>
+                </div>
               </div>
-            </div>
+            )}
 
             <div className={styles.reviewRow}>
               <span className={styles.reviewLabel}>Flag</span>

--- a/frontend/src/i18n/ar.json
+++ b/frontend/src/i18n/ar.json
@@ -51,7 +51,8 @@
     "existingReportsMore_two": "+ تقريران آخران",
     "existingReportsMore_few": "+ {{count}} تقارير أخرى",
     "existingReportsMore_many": "+ {{count}} تقريرًا آخر",
-    "existingReportsMore_other": "+ {{count}} تقرير آخر"
+    "existingReportsMore_other": "+ {{count}} تقرير آخر",
+    "priorityHeading": "صور مطلوبة هنا"
   },
   "photo": {
     "title": "التقاط صورة",

--- a/frontend/src/i18n/en.json
+++ b/frontend/src/i18n/en.json
@@ -43,7 +43,8 @@
     "viewExisting": "View existing reports",
     "hideExisting": "Hide existing reports",
     "existingReportsMore_one": "+ {{count}} more",
-    "existingReportsMore_other": "+ {{count}} more"
+    "existingReportsMore_other": "+ {{count}} more",
+    "priorityHeading": "Photos needed here"
   },
   "photo": {
     "title": "Take a Photo",

--- a/frontend/src/i18n/es.json
+++ b/frontend/src/i18n/es.json
@@ -43,7 +43,8 @@
     "viewExisting": "Ver informes existentes",
     "hideExisting": "Ocultar informes existentes",
     "existingReportsMore_one": "+ {{count}} más",
-    "existingReportsMore_other": "+ {{count}} más"
+    "existingReportsMore_other": "+ {{count}} más",
+    "priorityHeading": "Fotos requeridas aquí"
   },
   "photo": {
     "title": "Tomar una foto",

--- a/frontend/src/i18n/fr.json
+++ b/frontend/src/i18n/fr.json
@@ -43,7 +43,8 @@
     "viewExisting": "Voir les rapports existants",
     "hideExisting": "Masquer les rapports existants",
     "existingReportsMore_one": "+ {{count}} de plus",
-    "existingReportsMore_other": "+ {{count}} de plus"
+    "existingReportsMore_other": "+ {{count}} de plus",
+    "priorityHeading": "Photos requises ici"
   },
   "photo": {
     "title": "Prendre une photo",

--- a/frontend/src/i18n/ru.json
+++ b/frontend/src/i18n/ru.json
@@ -47,7 +47,8 @@
     "existingReportsMore_one": "+ ещё {{count}}",
     "existingReportsMore_few": "+ ещё {{count}}",
     "existingReportsMore_many": "+ ещё {{count}}",
-    "existingReportsMore_other": "+ ещё {{count}}"
+    "existingReportsMore_other": "+ ещё {{count}}",
+    "priorityHeading": "Здесь нужны фотографии"
   },
   "photo": {
     "title": "Сделать фото",

--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -38,7 +38,8 @@
     "viewExisting": "Mevcut raporları görüntüle",
     "hideExisting": "Mevcut raporları gizle",
     "existingReportsMore_one": "+ {{count}} rapor daha",
-    "existingReportsMore_other": "+ {{count}} rapor daha"
+    "existingReportsMore_other": "+ {{count}} rapor daha",
+    "priorityHeading": "Buraya fotoğraf gerekiyor"
   },
   "photo": {
     "title": "Fotoğraf Çekin",

--- a/frontend/src/i18n/zh.json
+++ b/frontend/src/i18n/zh.json
@@ -41,7 +41,8 @@
     "existingReportsLatest": "最新：{{damage}}（{{date}}）",
     "viewExisting": "查看已有报告",
     "hideExisting": "隐藏已有报告",
-    "existingReportsMore_other": "+ 还有 {{count}} 份"
+    "existingReportsMore_other": "+ 还有 {{count}} 份",
+    "priorityHeading": "此处需要照片"
   },
   "photo": {
     "title": "拍摄照片",

--- a/frontend/src/pages/dashboard.tsx
+++ b/frontend/src/pages/dashboard.tsx
@@ -40,6 +40,7 @@ export interface ReportFeature {
     analyst_damage_level: string | null;
     flag_status: "suspect" | "invalid" | null;
     flag_reason: string | null;
+    priority_flag: boolean;
   };
 }
 

--- a/infra/api_gateway.tf
+++ b/infra/api_gateway.tf
@@ -118,6 +118,12 @@ resource "aws_apigatewayv2_route" "get_reports_coverage" {
   target    = "integrations/${aws_apigatewayv2_integration.api.id}"
 }
 
+resource "aws_apigatewayv2_route" "get_buildings_priority" {
+  api_id    = aws_apigatewayv2_api.api.id
+  route_key = "GET /buildings/priority"
+  target    = "integrations/${aws_apigatewayv2_integration.api.id}"
+}
+
 # Protected routes — analyst dashboard reads + admin crisis CRUD.
 
 resource "aws_apigatewayv2_route" "get_reports" {
@@ -163,6 +169,14 @@ resource "aws_apigatewayv2_route" "delete_crisis_event" {
 resource "aws_apigatewayv2_route" "patch_report_review" {
   api_id             = aws_apigatewayv2_api.api.id
   route_key          = "PATCH /reports/{report_id}/review"
+  target             = "integrations/${aws_apigatewayv2_integration.api.id}"
+  authorization_type = "JWT"
+  authorizer_id      = aws_apigatewayv2_authorizer.cognito.id
+}
+
+resource "aws_apigatewayv2_route" "patch_building_priority" {
+  api_id             = aws_apigatewayv2_api.api.id
+  route_key          = "PATCH /buildings/{building_id}/priority"
   target             = "integrations/${aws_apigatewayv2_integration.api.id}"
   authorization_type = "JWT"
   authorizer_id      = aws_apigatewayv2_authorizer.cognito.id


### PR DESCRIPTION
## What was built

Analyst can flag any building for more photos — including buildings with no report yet. Flagged buildings appear with an amber dashed outline on the community map, directing the crowd to what's needed.

Creates a real-time feedback loop: analyst sees incomplete coverage → flags a building → community sees it highlighted → submits. Strong demo moment and a genuine differentiator over Ushahidi/KoboToolbox.

## How it works

**Analyst — dashboard map:** click any building footprint → confirmation popup appears ("Tag building as priority?" / "Flag for photos" button). Clicking confirm toggles the purple outline immediately and persists to the DB. Already-flagged buildings show "Priority flagged" / "Remove flag" in the same popup.

**Analyst — report modal:** "Photo request" toggle in the Analyst review section, for when the modal is already open. Only shown when the report has a `building_id`. Uses the same building endpoint.

**Community map:** flagged buildings show the same purple dashed outline. Assessed buildings get `priority_flag` from the coverage JOIN; unassessed buildings get it from a parallel `GET /buildings/priority` call — so the outline appears even on buildings with zero reports.

## Files changed

| File | Change |
|---|---|
| `db/011_priority_flag.sql` | `CREATE TABLE priority_buildings (building_id PK, flagged_at)` |
| `backend/reports.py` | `LEFT JOIN priority_buildings` in `query_reports` + `query_coverage`; new `get_priority_buildings` + `set_building_priority` |
| `backend/api.py` | `GET /buildings/priority` + `PATCH /buildings/:id/priority` |
| `dashboard-map.tsx` | `promoteId` on buildings source; priority fetch effect; `building-priority-outline` layer; footprint click → confirmation popup |
| `map.tsx` | Parallel fetch of `/buildings/priority` for unassessed buildings; feature-state for both assessed + unassessed |
| `report-details-modal.tsx` | Separate `togglePriority()` calling building endpoint; local `priorityFlag` state; hidden when `building_id` is null |
| `dashboard.tsx` | `priority_flag: boolean` on `ReportFeature` type (now sourced from JOIN) |

## DB migration — for Dan

`db/011_priority_flag.sql` creates one new table:

```sql
CREATE TABLE priority_buildings (
    building_id TEXT PRIMARY KEY,
    flagged_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
);
```

No FK constraints (building IDs come from PMTiles, not a DB table). No changes to existing tables. Safe to run at any point — the backend falls back cleanly before it exists (the LEFT JOIN returns NULL for priority_flag, which maps to `false` on the frontend).

If you're running this against the new target DB as part of the Supabase migration, it fits in sequence after migration 010 (which is on the unmerged #169/#170 branch) — or just after 009 if 010 hasn't landed yet.

## What was deferred

- No i18n on the popup/toggle — analyst-only UI, English sufficient
- No bulk-flag — out of scope for the demo flow
- No dashboard sidebar filter by priority flag — not needed for the scored requirements

## Manual test checklist

- [ ] Dashboard: zoom to level 14+ → click an unassessed building footprint → popup appears with "Tag building as priority?" heading and "Flag for photos" button
- [ ] Confirm: amber dashed outline appears on the building; clicking again shows "Priority flagged" / "Remove flag"
- [ ] Report modal: open a report with a building_id → "Photo request" row visible in Analyst review; toggles between active/inactive state
- [ ] Community map: after a building is flagged via the DB, zoom in → amber outline visible on that building

Closes #235