### PR TITLE
Hide E2E data from appearing in dashboard

### DIFF
--- a/backend/src/handlers/reports.py
+++ b/backend/src/handlers/reports.py
@@ -275,7 +275,10 @@ def create_report(body: dict) -> dict:
 
 def build_filter_clause(q: "ReportsQueryParams | object") -> tuple[str, list]:
     """Build the WHERE clause + params for any query honouring the standard report filters."""
-    conditions = ["is_latest = true"]
+    conditions = [
+        "is_latest = true",
+        "(device_id IS NULL OR device_id NOT LIKE 'device-e2e-%%')",
+    ]
     values: list = []
 
     if all(v is not None for v in (q.west, q.south, q.east, q.north)):

--- a/backend/tests/test_reports.py
+++ b/backend/tests/test_reports.py
@@ -155,6 +155,28 @@ class TestCreateReport:
         assert photo_key in params["photo_url"]
 
 
+class TestBuildFilterClause:
+    """The shared WHERE-clause builder used by query_reports, query_coverage, and exports."""
+
+    def test_excludes_e2e_tagged_reports(self):
+        from src.handlers.reports import ReportsQueryParams, build_filter_clause
+
+        q = ReportsQueryParams()
+        where, _ = build_filter_clause(q)
+        assert "device_id IS NULL OR device_id NOT LIKE 'device-e2e-%%'" in where  # %% so psycopg2 doesn't treat it as a placeholder
+
+    def test_e2e_filter_survives_building_id_branch(self):
+        """When filtering by building_id we drop is_latest but the E2E
+        filter must stay — otherwise analyst building-history lookups
+        would include synthetic test rows."""
+        from src.handlers.reports import ReportsQueryParams, build_filter_clause
+
+        q = ReportsQueryParams(building_id="vida-42")
+        where, _ = build_filter_clause(q)
+        assert "is_latest" not in where
+        assert "device_id NOT LIKE 'device-e2e-%%'" in where
+
+
 class TestQueryReports:
     @patch("src.handlers.reports.get_connection")
     def test_returns_geojson(self, mock_get_conn):

--- a/frontend/e2e/helpers.ts
+++ b/frontend/e2e/helpers.ts
@@ -9,11 +9,12 @@ export const TEST_PHOTO = join(__dirname, "fixtures", "test-photo.jpg");
 
 /**
  * Stub everything except POST /reports so tests don't hit the real backend
- * (no Bedrock calls, no S3 photo uploads, no synthetic data in prod).
- * Tests retain control over POST /reports via their own `page.route` calls
- * registered AFTER this helper.
+ * Reports are tagged and ignored
  */
 export async function stubNonReportsApi(page: Page): Promise<void> {
+  await page.addInitScript(() => {
+    (globalThis as unknown as { __E2E__: boolean }).__E2E__ = true;
+  });
   await page.route("**/photos/upload", (route) =>
     route.fulfill({
       status: 200,

--- a/frontend/src/utils/sync-engine.ts
+++ b/frontend/src/utils/sync-engine.ts
@@ -93,6 +93,12 @@ export const syncEngine = {
         await reportQueue.updateStatus(report.id, "syncing", { photoKey });
       }
 
+      const device_id =
+        typeof window !== "undefined" &&
+        (window as unknown as { __E2E__?: boolean }).__E2E__
+          ? `device-e2e-${crypto.randomUUID()}`
+          : undefined;
+
       const result = await api("/reports", {
         method: "POST",
         body: JSON.stringify({
@@ -117,6 +123,7 @@ export const syncEngine = {
           pressing_needs_other: report.surveyData.pressingNeedsOther || null,
           offline_queue_id: report.id,
           follow_up_responses: report.followUpResponses ?? null,
+          device_id,
         }),
       });
 


### PR DESCRIPTION
 - Tag E2E data
 - Hide it via WHERE clauses from all read endpoints (reports, export, etc.)