### PR TITLE
Fix missing Turkish translations (14 keys)

### DIFF
--- a/frontend/src/i18n/tr.json
+++ b/frontend/src/i18n/tr.json
@@ -7,7 +7,12 @@
     "syncing": "{{count}} rapor gönderiliyor...",
     "syncing_plural": "{{count}} rapor gönderiliyor...",
     "syncFailed": "{{count}} rapor gönderilemedi.",
-    "syncFailed_plural": "{{count}} rapor gönderilemedi."
+    "syncFailed_plural": "{{count}} rapor gönderilemedi.",
+    "failedPanelTitle": "Başarısız raporlar",
+    "failedPanelRetry": "Yeniden dene",
+    "failedPanelDiscard": "Sil",
+    "failedPanelRetryAll": "Tümünü yeniden dene",
+    "failedPanelEmpty": "Başarısız rapor yok"
   },
   "common": {
     "next": "İleri",
@@ -142,7 +147,11 @@
     "areaMilestone_one": "Bölgeniz aktif olarak izleniyor — {{count}} topluluk raporu ve artıyor",
     "areaMilestone_other": "Bölgeniz aktif olarak izleniyor — {{count}} topluluk raporu ve artıyor",
     "plusCodeLabel": "Konum kodu",
-    "copyPlusCode": "Konum kodunu kopyala"
+    "copyPlusCode": "Konum kodunu kopyala",
+    "shareButton": "Komşularınızla paylaşın",
+    "shareTitle": "Bölgenizdeki hasarı değerlendirmeye yardım edin",
+    "shareText": "Az önce bir hasar raporu gönderdim. Sizin de raporunuzu göndererek yardımcı olun — 2 dakikadan az sürer.",
+    "shareTextWithCrisis": "{{crisisName}} için az önce bir hasar raporu gönderdim. Sizin de raporunuzu göndererek yardımcı olun — 2 dakikadan az sürer."
   },
   "dashboard": {
     "title": "Gösterge Paneli",
@@ -174,7 +183,12 @@
     "legendSeverity": "Şiddet yoğunluğu",
     "legendLow": "Düşük",
     "legendHigh": "Yüksek",
-    "last24h": "son 24 saatte"
+    "last24h": "son 24 saatte",
+    "basemapStreet": "Sokak",
+    "basemapSatellite": "Uydu",
+    "layersPanel": "Katmanlar",
+    "layerBuildings": "Binalar",
+    "layerCrisis": "Kriz sınırı"
   },
   "coverage": {
     "ring": "{{total}} binadan {{assessed}} tanesi değerlendirildi",


### PR DESCRIPTION
## What

Adds 14 Turkish translation keys that were missing from `tr.json`, causing i18next to silently fall back to English for those strings.

Missing keys were spread across three feature areas:

| Group | Keys | Feature |
|---|---|---|
| `app.failedPanel*` | 5 | Failed reports retry panel (PR #192) |
| `confirmation.share*` | 4 | Share with neighbours button |
| `dashboard.basemap*` / `dashboard.layers*` | 5 | Basemap switcher + layer panel |

All other languages (EN, ES, FR, AR, RU, ZH) already had these keys. Turkish is now at parity (165/165 keys).

## Why this scope

Pure translation file fix — no logic, no component changes. `fallbackLng: "en"` in the i18next config was already handling these gracefully, so this is invisible unless you demo in Turkish, which Paul just did.

## Manual test

Switch language to Türkçe and verify:
- Confirmation screen share button reads "Komşularınızla paylaşın" (not English)
- Tap share — sheet title and pre-filled text are in Turkish
- Dashboard basemap toggle reads "Sokak" / "Uydu"
- Dashboard layers panel header reads "Katmanlar"
- Failed reports panel (trigger by going offline and submitting) shows Turkish strings