### PR TITLE
CI: fail PR if any language file is missing i18n keys

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -35,6 +35,9 @@ jobs:
         working-directory: frontend
         run: npm run build
 
+      - name: Check i18n completeness
+        run: node frontend/scripts/check-i18n-completeness.js
+
   backend:
     runs-on: ubuntu-latest
     steps:

--- a/frontend/scripts/check-i18n-completeness.js
+++ b/frontend/scripts/check-i18n-completeness.js
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+// Fails if any language file is missing keys that exist in en.json.
+// Plural-aware: for i18next plural groups (_one/_other etc.) a language only
+// needs at least one suffix variant, not every one English defines.
+// Run: node frontend/scripts/check-i18n-completeness.js
+
+import { createRequire } from 'module';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+
+const require = createRequire(import.meta.url);
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const en = require(join(__dirname, '../src/i18n/en.json'));
+const languages = ['ar', 'zh', 'fr', 'ru', 'es', 'tr'];
+
+const PLURAL_SUFFIXES = /_(zero|one|two|few|many|other)$/;
+
+function getKeys(obj, prefix = '') {
+  return Object.entries(obj).flatMap(([k, v]) => {
+    const key = prefix ? `${prefix}.${k}` : k;
+    return typeof v === 'object' && v !== null ? getKeys(v, key) : [key];
+  });
+}
+
+// Derive required base keys from en.json. For plural groups, record the base
+// once; for plain keys, the key itself is required.
+function requiredBases(keys) {
+  const bases = new Set();
+  for (const key of keys) {
+    bases.add(key.replace(PLURAL_SUFFIXES, ''));
+  }
+  return bases;
+}
+
+const enKeys = getKeys(en);
+const enBases = requiredBases(enKeys);
+let failed = false;
+
+for (const lang of languages) {
+  const translation = require(join(__dirname, `../src/i18n/${lang}.json`));
+  const trKeys = getKeys(translation);
+  // For each key in the target, record both the key itself and its base.
+  const trPresent = new Set(trKeys.flatMap(k => [k, k.replace(PLURAL_SUFFIXES, '')]));
+  const missing = [...enBases].filter(base => !trPresent.has(base));
+  if (missing.length) {
+    console.error(`❌ ${lang}: missing ${missing.length} key(s):\n  ${missing.join('\n  ')}`);
+    failed = true;
+  }
+}
+
+if (failed) {
+  console.error('\nAdd the missing keys to each language file to fix this check.');
+  process.exit(1);
+}
+
+console.log(`✅ All ${languages.length} language files complete (${enBases.size} base keys checked).`);

--- a/frontend/scripts/check-i18n-completeness.js
+++ b/frontend/scripts/check-i18n-completeness.js
@@ -7,12 +7,16 @@
 import { createRequire } from 'module';
 import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
+import { readdirSync } from 'fs';
 
 const require = createRequire(import.meta.url);
 const __dirname = dirname(fileURLToPath(import.meta.url));
 
-const en = require(join(__dirname, '../src/i18n/en.json'));
-const languages = ['ar', 'zh', 'fr', 'ru', 'es', 'tr'];
+const i18nDir = join(__dirname, '../src/i18n');
+const en = require(join(i18nDir, 'en.json'));
+const languages = readdirSync(i18nDir)
+  .filter(f => f.endsWith('.json') && f !== 'en.json')
+  .map(f => f.replace('.json', ''));
 
 const PLURAL_SUFFIXES = /_(zero|one|two|few|many|other)$/;
 
@@ -38,7 +42,7 @@ const enBases = requiredBases(enKeys);
 let failed = false;
 
 for (const lang of languages) {
-  const translation = require(join(__dirname, `../src/i18n/${lang}.json`));
+  const translation = require(join(i18nDir, `${lang}.json`));
   const trKeys = getKeys(translation);
   // For each key in the target, record both the key itself and its base.
   const trPresent = new Set(trKeys.flatMap(k => [k, k.replace(PLURAL_SUFFIXES, '')]));


### PR DESCRIPTION
Closes #266

## What

Adds a `check-i18n-completeness.js` script and a CI step that fails the `frontend` job if any language file is missing keys relative to `en.json`.

Plural-aware: languages like Chinese that only define `_other` (no `_one`) pass correctly — the check requires at least one suffix variant per plural group, not every suffix English defines.

## Why

PR #265 patched 14 missing Turkish keys that were only caught during a live demo. The fallback to English is silent — the app doesn't break, it just renders English strings for affected users. This check makes the gap visible at PR time instead.

## What the check does

- Derives all base keys from `en.json` (161 after collapsing plural suffixes)
- For each of the 6 non-English language files, verifies every base key is present
- Prints exactly which keys are missing per language and exits non-zero